### PR TITLE
pattern/dedicated-community-leader

### DIFF
--- a/dedicated-community-leader.md
+++ b/dedicated-community-leader.md
@@ -12,21 +12,15 @@ Selecting the wrong persons and/or not providing enough capacity for them risks 
 
 ## Story
 
-Consider the following story. A company wants to initiate an InnerSource initiative in order to foster collaboration across organizational boundaries. They have decided to start with an experimental phase with limited scope. Management has selected a suitable pilot topic for the first InnerSource community and expects contributions from many business units across the organization. The company has nominated a new hire to head the community for 50 % of his work time, because he was not yet 100 % planned for. After 6 months, the community has received only a few contributions, most of which are from a single business unit. The company replaces the community leader with someone who has a longer history in the company, this time for only 30 % of his time. After another 6 months, the number of contributions has picked up only  marginally. The company is no longer convinced that InnerSource helps to achieve their goal of increased, cross divisional collaboration and abandons InnerSource. 
+Consider the following story. A company wants to start an InnerSource initiative in order to foster collaboration across organizational boundaries. They have decided to start with an experimental phase with limited scope. Management has selected a suitable pilot topic for the first InnerSource community and expects contributions from many business units across the organization. The company has nominated a new hire to head the community for 50 % of his work time, because he was not yet 100 % planned for. After 6 months, the community has received only a few contributions, most of which are from a single business unit. The company replaces the community leader with someone who has a longer history in the company, this time for only 30 % of his time. After another 6 months, the number of contributions has picked up only  marginally. The company is no longer convinced that InnerSource helps to achieve their goal of increased, cross divisional collaboration and abandons InnerSource. 
 
 ## Context
 
 - The company is a large and old company. It has no prior experience in Open Source or other, community based working models. The company culture is best characterized as a classical top-down management style - it is generally at odds with community culture.
 - While there are supporters and a sponsor in top level management, middle management in the company is not yet sold on InnerSource.
-- Management has provided a limited budget to fund a part time community leader only.
+- Management was not convinced to provide more than a limited budget to fund a part time community leader, only.
 - The initially selected community leader has little or no prior experience with the Open Source working model.
 - The initially selected developer community leader does not have an extensive network within the company.
-
-**Review Comments**
-- (**Done**) clarify who actually bought in to which extent
-- (**Done**) clarify how many resources are available to the InnerSource effort (marketing, capacity)
-- (**Done**) add to first context bullet point: traditional companies might not have the right culture for communities to form naturally without much external stimulation and support.
-- (**Done**) clarify size of company
 
 ## Forces
 
@@ -34,26 +28,29 @@ If a company does not significantly invest in the initial InnerSource community 
 
 The value contribution of InnerSource projects will not be obvious for many managers which are steeped in traditional project management methods. Those managers are less likely to assign one of their top people, who are usually in high demand by non InnerSource-projects, to an InnerSource project for a significant percentage of their work time.
 
-Community work - especially communication - make up for a significant percentage of a community leaders daily work. At the same time, he will likely also have to spearhead the initial development, too. In the face of limited capacity, inexperienced leaders will tend to focus on development and neglect communication. The barrier for potential contributors to make their first contribution and to commit to the community will be much higher if the community leader is hard to reach or is slow to respond to feedback and questions for lack of time. Furthermore, technically inexperienced leaders will most likely have a harder time to attract and retain highly experienced contributors than a top performer with a high degree of visibility within a company would have. 
+Communication takes up a significant percentage of a community managers daily work. At the same time, he or she will likely also have to spearhead the initial development, too. In the face of limited capacity, inexperienced leaders will tend to focus on development and neglect communication. The barrier for potential contributors to make their first contribution and to commit to the community will be much higher if the community leader is hard to reach or is slow to respond to feedback and questions for lack of time. Furthermore, technically inexperienced leaders will most likely have a harder time to attract and retain highly experienced contributors than a top performer with a high degree of visibility within a company would have. 
+r
 
 If a community can not grow fast enough and pick up enough speed, chances are they won't be able to convincingly demonstrate the potential of InnerSource.
 
-**Review comments**
-- (**Open**: I have added something to the problem statement instead) now added that to the maybe reference pattern tbd (start small, experiment then scale up as it has proven successful)
+If the company selects an experienced project or line manager steeped in traditional management methods to be the community leader, he or she is likely to focus on traditional management topics such as resource allocation, providing structure and reporting channels rather than leading by example through meritocratic principles. This will undermine the credibility of the InnerSource initiative in the eyes of developers. 
 
 ## Solution
 
 Select a community leader who:
 - is experienced in the Open Source working model or similar community based working models, 
 - has the required soft-skills to act as a natural leader,
-- is an excellent networker and who
-- inspires community members.
+- leads by example and thus justifies his position in the community meritocracy,
+- is an excellent networker,
+- inspires community members,
+- can communicate effectively to both executive management and developers and
+- is able to handle the managerial aspects of community work.
 
-Empower the community leader to dedicate 100 % of his time to community work including communication and development. 
+Empower the community leader to dedicate 100 % of his time to community work including communication and development. Inform management of the need to be sensitive to the views of the community when engendering a change in community management. Ideally, empower the community to nominate a community leader themselves.
 
 ## Resulting Context
 
-A community leader with the properties described above will lend a face and embody the companies commitment to InnerSource. It will make it more likely that other associates in his network will follow his lead and contribute to InnerSource. Over time, he will be able to build up a stable core team of developers and hence increase the chances of success for the InnerSource project. By convincingly a large enough audience within his company of the potential of InnerSource, he will make an important contribution to changing the company culture towards a community culture. 
+A community leader with the properties described above will lend a face and embody the companies commitment to InnerSource. It will make it more likely that other associates in his network will follow his lead and contribute to InnerSource. Over time, he or she will be able to build up a stable core team of developers and hence increase the chances of success for the InnerSource project. By convincingly a large enough audience within his company of the potential of InnerSource, he or she will make an important contribution to changing the company culture towards a community culture. 
 
 Having excellent and dedicated community leaders is a precondition for the success of InnerSource. It is, however, not a silver bullet. There are many challenges of InnerSource which are above and beyond what a community leader can tackle, such as budgetary, legal, fiscal or other organizational challenges.
 
@@ -75,7 +72,11 @@ _Reviewed Pattern_
 - Tim Yao
 - Padma Sudarsan
 - Nigel Green
+- Nick Yeates
+- Erin Bank
+- Daniel Izquierdo
 
 ## Changelog
 
-- **2016-11-06** - first review
+- **2016-11-06** - 1st review
+- **2017-04-06** - 2nd review

--- a/dedicated-community-leader.md
+++ b/dedicated-community-leader.md
@@ -4,14 +4,13 @@ _Dedicated Community Leader_
 
 ## Problem
 
-When starting an InnerSource initiative it is crucial to nominate the right people to lead the communities. Selecting the wrong persons and/or not providing enough capacity for them risks wasted effort and ultimately the failure of the InnerSource initiative.
+How do you ensure that a new InnerSource initiative has the right leadership to grow it's communities?
 
-Consider the following story. Company A wants to initiate an InnerSource initiative in order to foster collaboration across organizational boundaries. They have decided to start with an experimental phase with limited scope. Management has selected a suitable pilot topic for the first InnerSource community and expects contributions from many business units across the organization. Company A has nominated a new hire to head the community for 50 % of his work time, because he was not yet 100 % planned for. After 6 months, the community has received only a few contributions, most of which are from a single business unit. Company A replaces the community leader with someone who has a longer history in the company, this time for only 30 % of his time. After another 6 months, the number of contributions has picked up only  marginally. Company A is no longer convinced that InnerSource helps to achieve their goal of increased, cross divisional collaboration and abandons InnerSource. 
+Selecting the wrong persons and/or not providing enough capacity for them risks wasted effort and ultimately the failure of a new InnerSource initiative.
 
-**Review Comments**
-- (**Done**) add summary about underlying core problem present in this story at the beginning (possibly boldfaced)
-- (**Done**) add _kicker statement_ after summary to get people interested in the contents (something like a rationale, outcome. Example: "avoid wasted effort on InnerSource"). 
-- (**Done**) add information about initial scope of InnerSource initiative (start small)
+## Story
+
+Consider the following story. A company wants to initiate an InnerSource initiative in order to foster collaboration across organizational boundaries. They have decided to start with an experimental phase with limited scope. Management has selected a suitable pilot topic for the first InnerSource community and expects contributions from many business units across the organization. The company has nominated a new hire to head the community for 50 % of his work time, because he was not yet 100 % planned for. After 6 months, the community has received only a few contributions, most of which are from a single business unit. The company replaces the community leader with someone who has a longer history in the company, this time for only 30 % of his time. After another 6 months, the number of contributions has picked up only  marginally. The company is no longer convinced that InnerSource helps to achieve their goal of increased, cross divisional collaboration and abandons InnerSource. 
 
 ## Context
 

--- a/dedicated-community-leader.md
+++ b/dedicated-community-leader.md
@@ -1,0 +1,80 @@
+## Title
+
+_Dedicated Community Leader_
+
+## Problem
+
+When starting an InnerSource initiative it is crucial to nominate the right people to lead the communities. Selecting the wrong persons and/or not providing enough capacity for them risks wasted effort and ultimately the failure of the InnerSource initiative.
+
+Consider the following story. Company A wants to initiate an InnerSource initiative in order to foster collaboration across organizational boundaries. They have decided to start with an experimental phase with limited scope. Management has selected a suitable pilot topic for the first InnerSource community and expects contributions from many business units across the organization. Company A has nominated a new hire to head the community for 50 % of his work time, because he was not yet 100 % planned for. After 6 months, the community has received only a few contributions, most of which are from a single business unit. Company A replaces the community leader with someone who has a longer history in the company, this time for only 30 % of his time. After another 6 months, the number of contributions has picked up only  marginally. Company A is no longer convinced that InnerSource helps to achieve their goal of increased, cross divisional collaboration and abandons InnerSource. 
+
+**Review Comments**
+- (**Done**) add summary about underlying core problem present in this story at the beginning (possibly boldfaced)
+- (**Done**) add _kicker statement_ after summary to get people interested in the contents (something like a rationale, outcome. Example: "avoid wasted effort on InnerSource"). 
+- (**Done**) add information about initial scope of InnerSource initiative (start small)
+
+## Context
+
+- Company A is a large and old company. It has no prior experience in Open Source or other, community based working models. The company culture is best characterized as a classical top down management style - it is generally at odds with community culture.
+- While there are supporters and a sponsor in top level management, middle management in company A is not yet sold on InnerSource.
+- Management has provided a limited budget to fund a part time community leader, only.
+- The initially selected community leader has little or no prior experience with the Open Source working model.
+- The initially selected developer community leader does not have an extensive network within the company.
+
+**Review Comments**
+- (**Done**) clarify who actually bought in to which extent
+- (**Done**) clarify how many resources are available to the InnerSource effort (marketing, capacity)
+- (**Done**) add to first context bullet point: traditional companies might not have the right culture for communities to form naturally without much external stimulation and support.
+- (**Done**) clarify size of company
+
+## Forces
+
+If a company does not significantly invest in the initial InnerSource community in terms of budget and capacity for InnerSource, the credibility of its commitment to InnerSource might be perceived as questionable. A common impulse of a company with a traditional management culture to a project or initiative not performing as expected will be to replace its leader. Doing that without involving the community and following meritocratic principles will further undermine the companies commitment to InnerSource by highlighting the friction between the current company culture and the target culture - a community culture.
+
+The value contribution of InnerSource projects will not be obvious for many managers which are steeped in traditional project management methods. Those managers are less likely to assign one of their top people, who are usually in high demand by non InnerSource-projects, to an InnerSource project for a significant percentage of their work time.
+
+Community work - especially communication - make up for a significant percentage of a community leaders daily work. At the same time, he will likely also have to spearhead the initial development, too. In the face of limited capacity, inexperienced leaders will tend to focus on development and neglect communication. The barrier for potential contributors to make their first contribution and to commit to the community will be much higher if the community leader is hard to reach or is slow to respond to feedback and questions for lack of time. Furthermore, technically inexperienced leaders will most likely have a harder time to attract and retain highly experienced contributors than a top performer with a high degree of visibility within a company would have. 
+
+If a community can not grow fast enough and pick up enough speed, chances are they won't be able to convincingly demonstrate the potential of InnerSource.
+
+**Review comments**
+- (**Open**: I have added something to the problem statement instead) now added that to the maybe reference pattern tbd (start small, experiment then scale up as it has proven successful)
+
+## Solution
+
+Select a community leader who:
+- is experienced in the Open Source working model or similar community based working models, 
+- has the required soft-skills to act as a natural leader,
+- is an excellent networker and who
+- inspires community members.
+
+Empower the community leader to dedicate 100 % of his time to community work including communication and development. 
+
+## Resulting Context
+
+A community leader with the properties described above will lend a face and embody the companies commitment to InnerSource. It will make it more likely that other associates in his network will follow his lead and contribute to InnerSource. Over time, he will be able to build up a stable core team of developers and hence increase the chances of success for the InnerSource project. By convincingly a large enough audience within his company of the potential of InnerSource, he will make an important contribution to changing the company culture towards a community culture. 
+
+Having excellent and dedicated community leaders is a precondition for the success of InnerSource. It is, however, not a silver bullet. There are many challenges of InnerSource which are above and beyond what a community leader can tackle, such as budgetary, legal, fiscal or other organizational challenges.
+
+## Known Instances
+
+_BIOS at Robert Bosch GmbH_. Note that InnerSource at Bosch was, for the majority, aimed at increasing innovation and to a large degree dealt with internal facing products. This pattern is currently not used at Bosch for lack of funding.
+
+## Status
+
+_Reviewed Pattern_
+
+## Authors
+
+- Georg Grütter (Robert Bosch GmbH)
+- Diogo Fregonese (Robert Bosch GmbH)
+
+## Acknowledgements
+
+- Tim Yao
+- Padma Sudarsan
+- Nigel Green
+
+## Changelog
+
+- **2016-11-06** - first review

--- a/dedicated-community-leader.md
+++ b/dedicated-community-leader.md
@@ -1,10 +1,12 @@
 ## Title
 
-_Dedicated Community Leader_
+_Dedicated Community Manager_
+
+alternative:_Dedicated Community Leader_
 
 ## Problem
 
-How do you ensure that a new InnerSource initiative has the right leadership to grow it's communities?
+How do you ensure that a new InnerSource initiative has the right [community manager](http://www.artofcommunityonline.org/) to grow it's impact?
 
 Selecting the wrong persons and/or not providing enough capacity for them risks wasted effort and ultimately the failure of a new InnerSource initiative.
 
@@ -14,9 +16,9 @@ Consider the following story. A company wants to initiate an InnerSource initiat
 
 ## Context
 
-- Company A is a large and old company. It has no prior experience in Open Source or other, community based working models. The company culture is best characterized as a classical top down management style - it is generally at odds with community culture.
-- While there are supporters and a sponsor in top level management, middle management in company A is not yet sold on InnerSource.
-- Management has provided a limited budget to fund a part time community leader, only.
+- The company is a large and old company. It has no prior experience in Open Source or other, community based working models. The company culture is best characterized as a classical top-down management style - it is generally at odds with community culture.
+- While there are supporters and a sponsor in top level management, middle management in the company is not yet sold on InnerSource.
+- Management has provided a limited budget to fund a part time community leader only.
 - The initially selected community leader has little or no prior experience with the Open Source working model.
 - The initially selected developer community leader does not have an extensive network within the company.
 


### PR DESCRIPTION
When starting an InnerSource initiative it is crucial to nominate the right people to lead the communities. Selecting the wrong persons and/or not providing enough capacity for them risks wasted effort and ultimately the failure of the InnerSource initiative. The person needs both communication skills as well as technical.

Reviewers not yet on github:
Nigel Green
Diogo Fregonese