### PR TITLE
pattern/poor-naming-conventions

### DIFF
--- a/poor-naming-conventions.md
+++ b/poor-naming-conventions.md
@@ -1,0 +1,48 @@
+## Title
+* Poor Naming Conventions Impact Findability (formerly Badly Named Piles)
+
+## Problem
+People can't find the internally developed solutions that they need due to poor naming conventions.
+
+## Context
+* Reusable Software component(s) are available internally but users can't easily find them.
+* This problem is more likely to occur in larger, siloed companies. 
+* Historically, the company does not have a culture of sharing code across silos. 
+
+## Forces
+* Enough people are contributing things to inner sourcing that it is becoming hard to find components.
+* Poor internal search engine (or not connected to git repositories; and difficult to make this change happen)
+* Users may not be able to find the people responsible even if they know where the common places are.
+* People become discouraged from engaging in inner source when they search and can't find what they need.
+* It can be difficult enough to find stuff in github, this is compounded if names are cryptic and keywords aren't used.
+
+## Solution
+* Improve findability within a repo. Use meaningful project name; don't use code names for projects; put keywords into descriptions.
+    - **note: problem/pattern: solution exists but people aren't following it**
+        - **ask PayPal folks about their practices set up to address this problem**
+        * Use tagging (tag repositories) (_validated_)
+        * Use labels
+        * Pull Repo names, descriptions, and README.md files into the search engine (not the code itself)
+        * Instate a process change to first check for internal solutions for this problem
+        * Concierge service (guide) to help product people find stuff. Might not scale but could be helpful in the beginning.
+	-Encourage the community to identify redundancy and make recommendations for the better package to use. Could be a dedicated role within a company, someone with a complete overview of what is going on
+
+## Known instances
+
+## Desired Resulting Context
+* Internal components are visible.
+* Developers looking for code can search for it and find it quickly.
+* Developers are now looking internally for software components.
+* Increased reuse, faster time to market.
+* Increased collaboration.
+* Higher quality code.
+* Increased opportunities for innovation.
+
+## Status
+Brainstormed pattern idea reviewed
+
+## Authors
+* Georg Grutter
+* Erin Bank
+* Padma Sudarsan
+* Tim Yao

--- a/poor-naming-conventions.md
+++ b/poor-naming-conventions.md
@@ -1,45 +1,44 @@
 ## Title
 
-- Poor Naming Conventions Impact Findability 
+Poor Naming Conventions Impact Findability 
 
-## Problem
+## Also Known As
 
-People cannot find the internally developed solutions that they need due to poor naming conventions applied to InnerSource projects.
+Badly Named Piles
 
 ## Context
 
-- Reusable software components exist and are accessible.
-- The company is large, siloed and does not have a history of code sharing and collaboration. 
-- The volume of inner source contributions is high.
-- A search engine exists, but required fixes to discover code reliably would be costly, complex.
+Reusable Software component(s) are available internally but users can't easily find them.
+This problem is more likely to occur in large, federated companies where different organizational units operate as silos.
+Historically, the company does not have a culture of sharing code across silos.
+
+## Problem
+
+People can't find the internally developed solutions that they need due to poor naming conventions.
 
 ## Forces
 
-- Search engine issues (such as lack of connection to codes sources) lead to problems with findability 
-- The code is findable, but information on ownership is not provided.
+- Enough people are contributing things to inner sourcing that it is becoming hard to find components.
+- Poor internal search engine (or not connected to git repositories; and difficult to make this change happen)
+- Users may not be able to find the people responsible even if they know where the common places are.
 - People become discouraged from engaging in inner source when they search and can't find what they need.
-- It can be difficult enough to find stuff in github, this is compounded if names are cryptic and keywords aren't used.
-- Renaming components can lead to broken builds.
+- It can be difficult enough to find stuff in GitHub, this is compounded if names are cryptic and keywords aren't used.
 
 ## Solution
 
-- Improve findability of components by using meaningful names.
-- Choose a naming scheme that references the coponents context (e. g. the
-  owning organization, products in which it is used)
-- Add metadata to components
-    - In the component description
-    - Tag the repository (_validated_)
-- Pull Repo names, descriptions, and README.md files into the search
-  engine (not the code itself)
-- Enforce naming conventions for components by making them a precondition for 
-  entering the automated release process. (_validated at PayPal_)
-- Establish a _concierge service_ (guide) to help people find components. Might 
-  not scale but could be helpful in the beginning.  
-- Encourage the community to identify redundancy and make recommendations for 
-  the better component to use and thus deduplicate. Could be a dedicated role 
-  within a company, someone with a complete overview of what is going on
+Improve findability within a repository. don't use code names for projects; put keywords into descriptions.
+note: problem/pattern: solution exists but people aren't following it
+
+-  Use meaningful project name; 
+-  Use tagging (tag repositories) (validated)
+-  Use labels
+-  Pull Repository names, descriptions, and README.md files into the search engine (not the code itself)
+-  Instate a process change to first check for internal solutions for this problem
+-  Concierge service (guide) to help product people find stuff. Might not scale but could be helpful in the beginning. 
+-  Encourage the community to identify redundancy and make recommendations for the better package to use. Could be a dedicated role within a company, someone with a complete overview of what is going on.
 
 ## Known instances
+None known as of yet---this is a pattern idea until it is proven.
 
 ## Desired Resulting Context
 
@@ -53,12 +52,13 @@ People cannot find the internally developed solutions that they need due to poor
 
 ## Status
 
-Brainstormed pattern idea reviewed
+Brainstormed pattern idea reviewed 2017-03-11.
 
 ## Authors
 
-- Georg Grutter
-- Erin Bank
-- Padma Sudarsan
-- Tim Yao
+- Georg Grutter (Robert Bosch GmbH)
+- Diogo Fregonese (Robert Bosch GmbH)
+- Erin Bank (CA Technologies)
+- Padma Sudarsan (Nokia)
+- Tim Yao (Nokia)
 

--- a/poor-naming-conventions.md
+++ b/poor-naming-conventions.md
@@ -1,18 +1,19 @@
 ## Title
-* Poor Naming Conventions Impact Findability (formerly Badly Named Piles)
+* Poor Naming Conventions Impact Findability 
 
 ## Problem
-People can't find the internally developed solutions that they need due to poor naming conventions.
+People cannot find the internally developed solutions that they need due to poor naming conventions applied to InnerSource projects.
 
 ## Context
-* Reusable Software component(s) are available internally but users can't easily find them.
-* This problem is more likely to occur in larger, siloed companies. 
-* Historically, the company does not have a culture of sharing code across silos. 
+* Reusable software components exist and are available internally.
+* Larger, siloed company. 
+* The company does not have a history of code sharing and collaboration. 
+* High volume of inner source contributions.
+* Search engine fixes would be costly and complex and are unlikely to be implemented.
 
 ## Forces
-* Enough people are contributing things to inner sourcing that it is becoming hard to find components.
-* Poor internal search engine (or not connected to git repositories; and difficult to make this change happen)
-* Users may not be able to find the people responsible even if they know where the common places are.
+* Search engine issues (such as lack of connection to codes sources) lead to problems with findability 
+* The code is findable, but information on ownership is not provided.
 * People become discouraged from engaging in inner source when they search and can't find what they need.
 * It can be difficult enough to find stuff in github, this is compounded if names are cryptic and keywords aren't used.
 

--- a/poor-naming-conventions.md
+++ b/poor-naming-conventions.md
@@ -1,49 +1,64 @@
 ## Title
-* Poor Naming Conventions Impact Findability 
+
+- Poor Naming Conventions Impact Findability 
 
 ## Problem
+
 People cannot find the internally developed solutions that they need due to poor naming conventions applied to InnerSource projects.
 
 ## Context
-* Reusable software components exist and are available internally.
-* Larger, siloed company. 
-* The company does not have a history of code sharing and collaboration. 
-* High volume of inner source contributions.
-* Search engine fixes would be costly and complex and are unlikely to be implemented.
+
+- Reusable software components exist and are accessible.
+- The company is large, siloed and does not have a history of code sharing and collaboration. 
+- The volume of inner source contributions is high.
+- A search engine exists, but required fixes to discover code reliably would be costly, complex.
 
 ## Forces
-* Search engine issues (such as lack of connection to codes sources) lead to problems with findability 
-* The code is findable, but information on ownership is not provided.
-* People become discouraged from engaging in inner source when they search and can't find what they need.
-* It can be difficult enough to find stuff in github, this is compounded if names are cryptic and keywords aren't used.
+
+- Search engine issues (such as lack of connection to codes sources) lead to problems with findability 
+- The code is findable, but information on ownership is not provided.
+- People become discouraged from engaging in inner source when they search and can't find what they need.
+- It can be difficult enough to find stuff in github, this is compounded if names are cryptic and keywords aren't used.
+- Renaming components can lead to broken builds.
 
 ## Solution
-* Improve findability within a repo. Use meaningful project name; don't use code names for projects; put keywords into descriptions.
-    - **note: problem/pattern: solution exists but people aren't following it**
-        - **ask PayPal folks about their practices set up to address this problem**
-        * Use tagging (tag repositories) (_validated_)
-        * Use labels
-        * Pull Repo names, descriptions, and README.md files into the search engine (not the code itself)
-        * Instate a process change to first check for internal solutions for this problem
-        * Concierge service (guide) to help product people find stuff. Might not scale but could be helpful in the beginning.
-	-Encourage the community to identify redundancy and make recommendations for the better package to use. Could be a dedicated role within a company, someone with a complete overview of what is going on
+
+- Improve findability of components by using meaningful names.
+- Choose a naming scheme that references the coponents context (e. g. the
+  owning organization, products in which it is used)
+- Add metadata to components
+    - In the component description
+    - Tag the repository (_validated_)
+- Pull Repo names, descriptions, and README.md files into the search
+  engine (not the code itself)
+- Enforce naming conventions for components by making them a precondition for 
+  entering the automated release process. (_validated at PayPal_)
+- Establish a _concierge service_ (guide) to help people find components. Might 
+  not scale but could be helpful in the beginning.  
+- Encourage the community to identify redundancy and make recommendations for 
+  the better component to use and thus deduplicate. Could be a dedicated role 
+  within a company, someone with a complete overview of what is going on
 
 ## Known instances
 
 ## Desired Resulting Context
-* Internal components are visible.
-* Developers looking for code can search for it and find it quickly.
-* Developers are now looking internally for software components.
-* Increased reuse, faster time to market.
-* Increased collaboration.
-* Higher quality code.
-* Increased opportunities for innovation.
+
+- Internal components are visible.
+- Developers looking for code can search for it and find it quickly.
+- Developers are now looking internally for software components.
+- Increased reuse, faster time to market.
+- Increased collaboration.
+- Higher quality code.
+- Increased opportunities for innovation.
 
 ## Status
+
 Brainstormed pattern idea reviewed
 
 ## Authors
-* Georg Grutter
-* Erin Bank
-* Padma Sudarsan
-* Tim Yao
+
+- Georg Grutter
+- Erin Bank
+- Padma Sudarsan
+- Tim Yao
+


### PR DESCRIPTION
People can't find the internally developed solutions that they need due to poor naming conventions. This causes frustration in finding inner source solutions and a reduction in code reuse.

Formerly called: Badly Named Piles