### PR TITLE
Fixed/added crosslinks

### DIFF
--- a/30-day-warranty.md
+++ b/30-day-warranty.md
@@ -77,4 +77,4 @@ Drafted at the 2017 Spring InnerSource Summit; reviewed 18 July 2017.
 # Variants
 
 - Ensure cooperation of dependent teams by making them a community by having
-  more than one, meritocratically appointed "Trusted Committers" (TCs) take responsibility.
+  more than one, meritocratically appointed "[Trusted Committers](https://github.com/paypal/InnerSourcePatterns/blob/master/project-roles/trusted-committer.md)" (TCs) take responsibility.

--- a/contracted-contributor.md
+++ b/contracted-contributor.md
@@ -111,7 +111,7 @@ empowering middle management to sign off on it:
 A formal contracting is also beneficial for contributors and communities:
 
 - With a stable group of contributors, it is more likely that some of them will
-  eventually achieve trusted committer status.
+  eventually achieve [Trusted Committer](https://github.com/paypal/InnerSourcePatterns/blob/master/project-roles/trusted-committer.md) status.
 - A formal contracting provides a basis for resolving conflict related to
   participation in InnerSource activities. Note that mediate will likely be
   successful only for a few companies with a culture condusive to that.

--- a/discover-your-innersource.md
+++ b/discover-your-innersource.md
@@ -55,7 +55,7 @@ Make it easy to find the reusable code.
 * Developers are now looking internally for software components
 * Search results are combined (internal and external)
 * Process changes, establishing a common communications channel, and encouraging and rewarding owners of reusable code to use the same search engine can contribute to changing the corporate culture. Transformation begins from the grassroots but requires strategic involvement of thought leaders. 
-* See [Improved Findability](https://github.com/paypal/InnerSourcePatterns/blob/master/poor-naming-conventions.md) (aka Poor Naming Conventions or Badly Named Piles) as a related pattern.
+* See [Improved Findability](https://github.com/paypal/InnerSourcePatterns/blob/master/improve-findability.md) (aka Poor Naming Conventions or Badly Named Piles) as a related pattern.
 
 ## Status
 Brainstormed pattern idea in progress

--- a/praise-participants.md
+++ b/praise-participants.md
@@ -12,7 +12,7 @@ Praise and thanks are easy, affordable ways to keep contributors and their manag
 A pattern in this area makes it easy to do and ensures that the message comes across clearly and sincerely.
 
 ## Context
-* You are the trusted committer or maintainer on an inner source project.
+* You are the [Trusted Committer](https://github.com/paypal/InnerSourcePatterns/blob/master/project-roles/trusted-committer.md) or maintainer on an inner source project.
 * You value the community of contributors and want to maintain and grow it.
 
 ## Forces


### PR DESCRIPTION
Added some cross-links to Trusted Committer where the term was already in use.
Fixed a (broken) cross-link between _discover-your-innersource_ and _improved-findability_
