### PR TITLE
Add first pattern on base documentation.

### DIFF
--- a/project-setup/base-documentation.md
+++ b/project-setup/base-documentation.md
@@ -23,7 +23,7 @@ exactly which colleagues are currently actively maintaining the project.
   get setup and get started.
 - Project members are spending a lot of time answering getting started
   questions.
-- Different teams withing the organization have diverging standards for how to
+- Different teams within the organization have diverging standards for how to
   format source code and which software patterns to use. As a result
   contributions often end up getting re-written to a large part or even
   entirely.
@@ -102,4 +102,3 @@ Europace AG, Paypal Inc.
 # State
 
 Drafted in December 2019.
-

--- a/project-setup/base-documentation.md
+++ b/project-setup/base-documentation.md
@@ -1,0 +1,105 @@
+# Title
+
+Standard base documentation
+
+# Context
+
+A project is to be shared with others as an InnerSource project. In order for
+others to be able to understand what the project is about as well as how to
+contribute, the project needs to provide some base level documentation.
+
+# Problem
+
+A team wants to share either a freshly started or a pre-existing project with
+the wider organization and receive contributions to it. Potential contributors
+often are lost: They are failing to identify the team's preferred communication
+channels. They have trouble quickly making a judgment about whether a new
+feature makes sense to be added or not. They have a hard time understanding
+exactly which colleagues are currently actively maintaining the project.
+
+# Forces
+
+- A lack of documentation leads to potential contributors taking a long time to
+  get setup and get started.
+- Project members are spending a lot of time answering getting started
+  questions.
+- Different teams withing the organization have diverging standards for how to
+  format source code and which software patterns to use. As a result
+  contributions often end up getting re-written to a large part or even
+  entirely.
+- The added work for repeated explanations and re-writes diminishes the
+  usefulness of the InnerSource approach.
+- Frequent escalations due to extra work and delays due to re-writes lead to a
+  big cheese situation.
+
+# Solution
+
+Address the need for clearer documentation for new contributors. The goal when
+creating this documentation should be to make getting started as much a self
+service process as possible with frequently asked questions answered in standard
+documentation format.
+
+If it does not yet exist, create a **README.md** for your project. It should
+contain:
+
+* The [mission of the
+  project](https://producingoss.com/en/producingoss.html#mission-statement) in
+  as a concise format as possible. It should answer what the project's purpose
+  is and enable contributors to make a good first guess whether a suggested
+  feature will likely be in scope for the project, or not.
+* A "Getting Started" section for downstream users of the project. It should
+  explain how to setup/ integrate the project artifacts as well as an
+  explanation of some of the first typical steps for first time users.
+* Deeper documentation for project users - or a link to that.
+* Documentation needed for making modifications to the project - or a link to
+  that.
+* Documentation on how to contribute to the project - or a link to that.
+* A "Getting involved" section that explains which public, archived, linkable
+  communication channels the project uses. This should include a link to the
+  project issue tracker, but also to any further discussion media used.
+* A "Who we are" section explaining who the Trusted Committers behind the
+  project are - with an explanation that instead of contacting these people
+  privately the public communication channels above should be used for
+  communication.
+* An explanation of what the criteria are for the project to turn contributors
+  into Trusted Committers - if that path exists.
+
+If the explanation of the steps to make a contribution are too involved, create
+a separate **CONTRIBUTING.md** document. This document should answer frequently
+asked questions that contributors have asked in the past. There is no need to
+provide a comprehensive book up front. Rather share information that has proven
+needed by contributors. Likely it will touch upon one or more of the following
+topics:
+
+* How to checkout the project source code from version control.
+* How to make modifications to the project (potentially including information on
+  coding guidelines.)
+* How to build the project.
+* How to run tests to make sure the above modifications aren't introducing new
+  bugs.
+* How to submit your modifications back to the project.
+* Some information on which turnaround time to expect for modifications made.
+
+# Resulting Context
+
+* The time for contributors to get up to speed is significantly reduced.
+* Time spent on answering initial questions for Trusted Committers is
+  significantly reduced leaving them more time to work on other tasks.
+* Escalations due to misunderstandings and misalignment are significantly
+  reduced.
+
+# Known Instances
+
+Europace AG, Paypal Inc.
+
+# Authors
+
+* Isabel Drost-Fromm
+
+# Acknoledgements
+
+
+# State
+
+Drafted in December 2019.
+

--- a/project-setup/base-documentation.md
+++ b/project-setup/base-documentation.md
@@ -1,12 +1,15 @@
 # Title
 
-Standard base documentation
+Provide standard base documentation through a README
 
 # Context
 
 A project is to be shared with others as an InnerSource project. In order for
 others to be able to understand what the project is about as well as how to
-contribute, the project needs to provide some base level documentation.
+contribute, the project needs to provide some base level documentation. So far
+the project is lacking either all documentation or some aspects needed for users
+to try it out in a self-service manner as well as for contributors to get up to
+speed quickly.
 
 # Problem
 
@@ -19,14 +22,36 @@ exactly which colleagues are currently actively maintaining the project.
 
 # Forces
 
+- The project was converted into an InnerSource project only recently. Before,
+  users were either only internal or on-boarded in personal face-to-face
+  sessions.  Equally, people working on the project went through personal
+  on-boarding sessions which do not scale with growing numbers of contributors or
+  remote contributors. As a result, self service documentation is lacking.
+- The project was newly created as an InnerSource project. However the host team
+  lacks experience with InnerSource. As a result they need guidance on which
+  information to include in their documentation, where to put that documentation
+  so others can find it and which types of readers to address in their
+  documentation.
+- The project was converted into an InnerSource project only recently, the host
+  team has limited experience with InnerSource. As a result, existing
+  documentation addresses a lot of technical aspects. It does not cover
+  communication, coordination, information needed to facilitate transparent
+  planning.
+- The project was converted into an InnerSource project only recently. As a
+  result, a lot of implicit knowledge that exists within the team is neither
+  written down nor obvious to contributors.
 - A lack of documentation leads to potential contributors taking a long time to
-  get setup and get started.
+  get setup and get started. Producing documentation (and keeping it up to date)
+  requires a time investment. Even if the host team relies on contributors to
+  help with lacking documentation, those contributions still need time to review.
 - Project members are spending a lot of time answering getting started
-  questions.
+  questions. Maintaining a comprehensive database of what could be considered
+  support questions requires a lot of time and effort though.
 - Different teams within the organization have diverging standards for how to
   format source code and which software patterns to use. As a result
   contributions often end up getting re-written to a large part or even
-  entirely.
+  entirely. Standardizing all of that and enforcing the standard often
+  would require a lot of time and work.
 - The added work for repeated explanations and re-writes diminishes the
   usefulness of the InnerSource approach.
 - Frequent escalations due to extra work and delays due to re-writes lead to a
@@ -67,7 +92,7 @@ contain:
 If the explanation of the steps to make a contribution are too involved, create
 a separate **CONTRIBUTING.md** document. This document should answer frequently
 asked questions that contributors have asked in the past. There is no need to
-provide a comprehensive book up front. Rather share information that has proven
+provide a comprehensive book up front. Rather, share information that has proven
 needed by contributors. Likely it will touch upon one or more of the following
 topics:
 
@@ -81,13 +106,20 @@ topics:
 * Some information on which turnaround time to expect for modifications made.
 
 
-There are literally tons of good examples for how to write a README.md and what kind
+There are many of good examples for how to write a README.md and what kind
 of information to include in a CONTRIBUTING.md file in various open source projects. 
 Pages like [how to write a readme that rocks](https://m.dotdev.co/how-to-write-a-readme-that-rocks-bc29f279611a), 
 [Open Source Guide from GitHub](https://opensource.guide/) as well as
-the book [Producing Open Source](https://producingoss.com/en/producingoss.html) all
-have valuable information on what kind of information to provide. In addition to that this
-pattern comes with two very basic templates to get you started right away.
+the book [Producing Open Source](https://producingoss.com/en/producingoss.html)
+all have valuable information on what kind of information to provide. While
+Producing Open Source does not have a chapter on writing a good README per se,
+the [Getting Started
+chapter](https://producingoss.com/en/producingoss.html#starting-from-what-you-have)
+does provide a fairly extensive list of things that fellow host team members,
+users and contributors will need. InnerSource projects likely will not cover all
+of those aspects right from the start, the list itself is helpful for
+inspiration for what one could cover. In addition to that, this pattern comes
+with two very basic templates to get you started right away.
 
 # Resulting Context
 

--- a/project-setup/base-documentation.md
+++ b/project-setup/base-documentation.md
@@ -80,6 +80,15 @@ topics:
 * How to submit your modifications back to the project.
 * Some information on which turnaround time to expect for modifications made.
 
+
+There are literally tons of good examples for how to write a README.md and what kind
+of information to include in a CONTRIBUTING.md file in various open source projects. 
+Pages like [how to write a readme that rocks](https://m.dotdev.co/how-to-write-a-readme-that-rocks-bc29f279611a), 
+[Open Source Guide from GitHub](https://opensource.guide/) as well as
+the book [Producing Open Source](https://producingoss.com/en/producingoss.html) all
+have valuable information on what kind of information to provide. In addition to that this
+pattern comes with two very basic templates to get you started right away.
+
 # Resulting Context
 
 * The time for contributors to get up to speed is significantly reduced.

--- a/project-setup/templates/CONTRIBUTING-template.md
+++ b/project-setup/templates/CONTRIBUTING-template.md
@@ -38,3 +38,14 @@ This section should contain information on
 - Code formatting guidelines,
 - How to run the test suite.
 
+## How to become a Trusted Committer
+
+This section should make the process for becoming a Trusted Committer explicit
+if that route is open to contributors.
+## How to nominate Trusted Committers
+
+This section serves as a reminder to existing and explanation for new Trusted
+Committers detailing how to add others to the host team. Again ideally this
+information is identical for all projects in the organisation so central
+information can be linked to from here. 
+

--- a/project-setup/templates/CONTRIBUTING-template.md
+++ b/project-setup/templates/CONTRIBUTING-template.md
@@ -1,0 +1,40 @@
+# Contributing to ____
+
+## Types of contributions
+
+Provide information on what kinds of contributions your project is looking for
+here. For example these can be bug reports, help with answering user questions,
+improving documentation, fixes to bugs, as well as new feature implementations.
+
+## Bug reports
+
+Add information on how to submit bug reports here. This should include
+hints about which type of information the project will need in order to
+reproduce and fix issues. It can also include information on commonly found
+mis-configurations that look like bugs.
+
+Also include information on what contributors can expect in terms of time to
+first response and process after that.
+
+## Feature requests
+
+Add information on how to submit feature requests here. Also include information
+on what contributors can expect in terms of time to first response and process
+after that.
+
+## Contributing documentation
+
+Include information on any documentation best practices your project follows as
+well as how to build documentation, checks to run and how to submit the changes
+made back to the project.
+
+## Contributing source code
+
+This section should contain information on
+
+- How to access the project source code,
+- General project layout,
+- Any requirements to the development environment,
+- Code formatting guidelines,
+- How to run the test suite.
+

--- a/project-setup/templates/README-template.md
+++ b/project-setup/templates/README-template.md
@@ -17,6 +17,16 @@ This section should contain brief documentation written for first time users on
 how to get started using the project. Further more detailed documentation can be
 linked to from here.
 
+## Further information
+
+This section can list any or all of the following:
+
+* A list of features, use cases that the software addresses.
+* Information on design principles that are used to resolve trade-offs
+* Links to further user level documentation
+* Answers to frequently asked questions (FAQ), preferably in a format that
+  allows to link to specific questions and their answers for easier reference.
+
 ## Getting help
 
 This section should contain a brief documentation on how to get help for the

--- a/project-setup/templates/README-template.md
+++ b/project-setup/templates/README-template.md
@@ -17,6 +17,14 @@ This section should contain brief documentation written for first time users on
 how to get started using the project. Further more detailed documentation can be
 linked to from here.
 
+## Getting help
+
+This section should contain a brief documentation on how to get help for the
+project as a user. This could be as simple as pointing users to the issue
+tracker if this is how your project would like to answer questions. It could
+also point to an archived and searchable chat channel, some archived searchable
+mailing list, some online user forum.
+
 ## Getting involved
 
 This section should include information on how to get in touch with the project:
@@ -33,18 +41,6 @@ the same definition that is only linked to from here. The reason to keep the
 link here is for colleagues who have no or little experience with working in and
 contributing to InnerSource projects to have a direct link back to company wide
 information from the technological projects they need for their daily work.
-
-### How to become a Trusted Committer
-
-This section should make the process for becoming a Trusted Committer explicit
-if that route is open to contributors.
-
-### How to nominate Trusted Committers
-
-This section serves as a reminder to existing and explanation for new Trusted
-Committers detailing how to add others to the host team. Again ideally this
-information is identical for all projects in the organisation so central
-information can be linked to from here. 
 
 ## Contributing
 
@@ -67,6 +63,11 @@ Ideally you also include information on what the preferred process for changes
 looks like for the project: Should contributors first open an issue and submit a
 proposal, or are they welcome to submit changes right away? What is important to
 you when reviewing contributions?
+
+In addition you should outline any design values you want to follow in the
+project. Making those explicit often helps resolve trade-offs more quickly and
+more easily. In addition it helps making changes to otherwise implicit
+assumptions transparent.
 
 Over time you will notice that this section grows substantially. In that case
 think about moving the information to separate files, e.g. a CONTRIBUTING.md and

--- a/project-setup/templates/README-template.md
+++ b/project-setup/templates/README-template.md
@@ -1,0 +1,73 @@
+# Insert the name of your project here
+
+## Mission
+
+This should contain a brief (3-5 sentences) description of the mission of your
+project. The goal is to state what you are planning to work on and help external
+contributors understand roughly which types of features will likely be welcome
+for this project.
+
+See also [mission statement
+chapter](https://producingoss.com/en/producingoss.html#mission-statement) in
+Producing Open Source Software.
+
+## Getting Started
+
+This section should contain brief documentation written for first time users on
+how to get started using the project. Further more detailed documentation can be
+linked to from here.
+
+## Getting involved
+
+This section should include information on how to get in touch with the project:
+Typically this will contain links to archived, searchable and linkable
+communication channels.
+
+## Who we are
+
+This is a good place to give credit to Trusted Committers of the project.
+
+It's also a good place to include information on what being a Trusted Committer
+means for this project - although ideally all projects in an organisation use
+the same definition that is only linked to from here. The reason to keep the
+link here is for colleagues who have no or little experience with working in and
+contributing to InnerSource projects to have a direct link back to company wide
+information from the technological projects they need for their daily work.
+
+### How to become a Trusted Committer
+
+This section should make the process for becoming a Trusted Committer explicit
+if that route is open to contributors.
+
+### How to nominate Trusted Committers
+
+This section serves as a reminder to existing and explanation for new Trusted
+Committers detailing how to add others to the host team. Again ideally this
+information is identical for all projects in the organisation so central
+information can be linked to from here. 
+
+## Contributing
+
+This section should document (or link to documentation) on all things that a
+first time contributor needs to know to get started. Typically not all of the
+topics below will be covered. Focus on what differs in your project from
+standard setup and what previous contributors found hard to understand.
+
+- Finding the source code.
+- Finding a list of issues that your project needs help with - these can be
+  both, technical and non-technical issues. Typically you will keep those in an
+  issue tracker accessible to contributors.
+- Links to further documentation e.g. about the architecture of the project,
+  general coding conventions, testing conventions...
+- For technical contributions: Making changes, building the project and testing
+  your changes.
+- Submitting your changes back to the project.
+
+Ideally you also include information on what the preferred process for changes
+looks like for the project: Should contributors first open an issue and submit a
+proposal, or are they welcome to submit changes right away? What is important to
+you when reviewing contributions?
+
+Over time you will notice that this section grows substantially. In that case
+think about moving the information to separate files, e.g. a CONTRIBUTING.md and
+TESTING.md 


### PR DESCRIPTION
This relates to #114

It takes a first stab at writing up the basics of InnerSource project setup starting with adding base documentation.

Essentially this is based on experience shared on our company blog at http://tech.europace.de 

While the components of basic project documentation are mentioned in the InnerSource Checklist book I think it makes sense to also include them in our pattern language so people have one place to look for best practices.