### PR TITLE
Link to markdown files that were missing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The topics below cover information about how we define, operate, and upkeep this
 
 * [Pattern Template](meta/pattern-template.md) - Start a new pattern with a copy of this
 * [Pattern States](meta/pattern-states.md) - Definitions of the various states and review steps a pattern can be in
+* [Pattern System](pattern-system.md) (draft) For a human reader it is not easy to digest a long list of patterns. We are working on labeling and classifying the patterns further. See [Pattern System](pattern-system.md) for our current thoughts.
 * [Trusted Committers](meta/trusted-committers.md) - Who these people are, what elevated rights they get, and how you can become one
 * [Publishing](meta/publishing.md) - How we take completed, reviewed, proven patterns and publish them toward an online book
 * [Markdown Info](meta/markdown-info.md) - Markdown is the ascii text format our patterns are written in; this document briefly defines how we use it

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ possible to either deploy the same service in independent environments with sepa
 #### Pattern Ideas (not yet proven; brainstormed)
 
 * [Don't Bother Looking](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/60)
-* [Junkyard Styled Inner Sourcing](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/61)
+* [Junkyard Styled Inner Sourcing](junkyard-styled-innersourcing.md)
 * [Shared Code Repo Different from Build Repo](https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Shared-Code-Repo-Different-from-Build-Repo) - *Deal with the overhead of having shared code in a separate repository that isn't the same as the project-specific one that is tied to production builds.*
 * [Incentive Alignment](https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Donut:-Creating-Developer-Incentive-Alignment-for-InnerSource-Contribution)
 * [Change the Developers Mindset](https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Pattern:-change-the-developers-mindset)
 * [Share Your Code to Get More Done - Likely Contributors Variant](https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Pattern:-Share-Your-Code-to-Get-More-Done---Likely-Contributors-Variant)
+* [Introducing Metrics in InnerSource](introducing-metrics-in-innersource.md) - *Involve all stakeholders in designing and interpreting metrics to measure the current status in terms of health and performance of the InnerSource initiative.*
 
 #### Pattern Donuts (needing a solution)
 
@@ -76,7 +77,7 @@ The pattern form is useful for describing proven patterns but it can also be use
 
 [See our CONTRIBUTING.md for details on getting involved](CONTRIBUTING.md)
 
-We encourage beginners seeking answers to jump in by creating ''donuts'' (problems without solutions). We encourage experts to pad their experience - these are hoped to become part of a book one day. Anyone can offer reviews and comments for [in-progress patterns](https://github.com/InnerSourceCommons/InnerSourcePatterns/pulls). 
+We encourage beginners seeking answers to jump in by creating ''donuts'' (problems without solutions). We encourage experts to pad their experience - these are hoped to become part of a book one day. Anyone can offer reviews and comments for [in-progress patterns](https://github.com/InnerSourceCommons/InnerSourcePatterns/pulls).
 
 We work together via Github, Webex, Slack, etc. Do not hesitate to join the [#innersourcecommons](https://isc-inviter.herokuapp.com/) or #innersource-patterns slack channels and ask to be included in the [patterns meetings](/meta/meetings.md) (there is an email list).
 
@@ -102,4 +103,3 @@ The topics below cover information about how we define, operate, and upkeep this
 ![Creative Commons License](https://i.creativecommons.org/l/by-sa/4.0/88x31.png)
 
 InnerSourcePatterns by [InnerSourceCommons.org](http://innersourcecommons.org) is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International](http://creativecommons.org/licenses/by-sa/4.0/) License.
-

--- a/introducing-metrics-in-innersource.md
+++ b/introducing-metrics-in-innersource.md
@@ -1,20 +1,19 @@
-# Title
+## Title
 
 Introducing Metrics in InnerSource
 
-# Patlet
+## Patlet
 
 Involve all stakeholders in designing and interpreting metrics to measure the
-current status in terms of _health_ and performance of the InnerSource 
+current status in terms of _health_ and performance of the InnerSource
 initiative.
 
-# Context
+## Context
 
 An organization is planning to apply or this is in the early stages of applying InnerSource. This would like to measure the current status in terms of 'health' and performance of the initiative, and if the expected outcomes such as an increase in the level of cross-divisional and cross-location collaboration are actually taking place.
 This pattern applies to early stages of the initiative or are small in their scope, but they may be mature in their initial process and steps.
 
-
-# Problem
+## Problem
 
 This organization may already have qualitative feedback from the
 involved teams, but desire more objective information focused
@@ -27,15 +26,14 @@ Changes in the top level initiatives may affect the InnerSource program
 as they rely in the good will of some executive from the organization.
 
 You may have a problem justifying the InnerSource effort when there is
-a change in business priorities or business leadership. Then you need 
+a change in business priorities or business leadership. Then you need
 something concrete to justify the program. A future problem you're
 guarding against.
 
 If there's a change in the C-level, metrics might be helpful to convince
 them that InnerSource is useful.
 
-
-# Forces
+## Forces
 
 People do not like to be tracked or measured.
 
@@ -49,7 +47,7 @@ Metrics are usually misunderstood if people have not received any
 training on those.
 
 Organizations collect vanity of any other type of metrics that do not
-track business objectives' sucess or failure over time.
+track business objectives' success or failure over time.
 
 Metrics tend to become goals, will subsequently be gamed and thus meaningless.
 
@@ -59,7 +57,7 @@ Some countries in some organizations may face extra complexity when introducing 
 
 Tools and how they use them. There might be a learning curve in the discussion about metrics. And perhaps the tools do not support the metrics we're looking for.
 
-# Solution
+## Solution
 
 Bring developers, middle managers and C-level to have a discussion
 about metrics. And consider other roles out of the usual development process such as
@@ -73,7 +71,7 @@ Consider third party and neutral player to produce such metrics.
 
 Have specific training on the topic of metrics and good practices
 to use them. An example is to have a methodology to follow metrics such
-as the Goal-Question-Metric approach or the Objetives-KeyResults one.
+as the Goal-Question-Metric approach or the Objectives-KeyResults one.
 On the other hand, try to update the metrics used to the short-term
 and medium-term goals.
 
@@ -90,7 +88,7 @@ to understand and follow.
 Note: any proposed metric are just examples and not the ones that should be using. Depending on the selection of business goals to track, those will match with specific set of metrics.
 
 
-# Resulting Context
+## Resulting Context
 
 The organization builds a monitoring infrastructure where the agreed
 metrics will be the ones to be used.
@@ -106,10 +104,13 @@ Those metrics will help developers to understand how the initiative
 evolves and help them with their daily work.
 
 
-# Known Instances
+## Known Instances
 
+## State
 
-# Authors
+Unproven
+
+## Authors
 
 - Daniel Izquierdo
 - Tim Yao
@@ -117,12 +118,7 @@ evolves and help them with their daily work.
 - Russ Rutledge
 - Tom
 
-# Acknowledgement
+## Acknowledgement
 
 - Georg
 - Bob
-
-# State
-
-Early Idea
-


### PR DESCRIPTION
Improves issue reported in #135 
 
This PR adds link to markdown files that were in this repo, but that were not linked from README.md. 
While at it, I also fixed the template format of `introducing-metrics-in-innersource.md`.

Details:
* .md files in this repo = 19
* .md files linked from README.md = 15

Explanation for the difference in count:

- [x] `README.md` itself - not a problem
- [x] `introducing-metrics-in-innersource.md` - link added 
- [x] `junkyard-styled-innersourcing.md` - link added
- [x] `pattern-system.md` - not sure what to do with this. maybe link from the `# What are Inner Source Patterns?` section in the README?
