### PR TITLE
Incorporate repo wiki into main repository

### DIFF
--- a/archive/meetings/meetings-14+15-raw.md
+++ b/archive/meetings/meetings-14+15-raw.md
@@ -1,0 +1,98 @@
+# Meeting 15 - Define Pattern Fields, Dedicated Community Leader
+2017-03-30 (Thursday)
+
+## Agenda
+
+* (25 mins) Go through some of [Pattern Fields for better definition](/meta/pattern-template.md)
+    * what a problem statement should be
+    * titling the pattern from the problem name, not the solution name
+    * Tags
+    * grouping similar patterns together
+* (30 mins) Preparing patterns for Geneva
+    * 3 patterns are on the cusp of being done - **k to highlight these**
+        * Dedicated Community Leader
+        * Common Requirements
+        * Contracted Contributor / Free Electron
+    * s's pattern will be ready for next week (revised, 2nd review)
+        * Need to get this on github
+* (If possible) g noted o guys had a nice InnerSource presentation on the Ford Motor Company in Germany; perhaps s can share this with us
+
+## Minutes
+
+None yet
+
+---
+
+# Meeting 14 - Spring Summit Prep, Hiring leverages culture, Start as Experiment
+2017-03-23 (Thursday)
+
+## Agenda
+* First 20 minutes
+  * Introductions if new people are present
+  * The book on InnerSource Patterns that Daniel is setting up
+  * Expanding the team
+  * Preparations for the Spring Summit
+* Remaining 40 minutes
+  * k: Early-Idea "Hiring leverages culture" for initial discussion.
+  * g: Start as Experiment / Contained InnerSource (proven pattern)
+  * ~~l: Change Developers Mindset (unproven idea)~~
+
+## Minutes
+
+### SUMMARY
+* Some discussion around the book that l has set up (prototype). The mechanism is great; we need to add a strong disclaimer and note the Creative Commons licensing. Further discussions will likely happen in Geneva.
+
+* e mentioned the possibility of using PayPal O’Reilly webinar credit to have us do an InnerSource Patterns webinar with them. The team here is interested in pursuing this (after the Spring Summit).
+
+* Our group will pursue getting more patterns ready for possible sharing at the Spring Summit. We will also look into submitting some finished patterns to PLOP or EuroPLOP (for patterns feedback).
+
+* We spent time with k’s pattern idea (early): Hiring Leverages (InnerSource) Culture; and reviewing g’s new pattern: Start as Experiment. g will bring back Contained InnerSource.
+
+* Next week’s meeting: same time/day: WebEx: 2017-03-30 (THURS) - 9 AM PDT/11 AM CDT/5 PM CET/6 PM EET/9:30 PM INDIA
+
+### DETAILED DRAFT NOTES
+In attendance
+m, o, g, n, k, b, d, a
+
+* b: Colleague had some specific comments (from the webinar).
+    – "Session was quite good; graphics for the forces were very good."
+### First 20 minutes
+* The book on InnerSource Patterns that l is setting up
+
+* k: l is working with c to get this hosted under Paypal space; can bring in one markdown file that points to other markdown files; then it automatically creates the book. Once we have patterns we can publish, it should be simple
+* m: Some unreviewed patterns appear in the book; we should be careful to have disclaimers so that people won’t misinterpret the contents..
+* k: We have to be careful what is there (it is a proof of concept); he's aware that these patterns aren't even close to being ready for the book.
+* m: Writing a book around the patterns? E.g., Fearless Change had a lot of anecdotes and discussion around each pattern.
+* b: Yes, be careful (patterns not reviewed). But would be useful to extract everything into a PDF (a good thing long term). Patterns should be standalone; think about the reader of the pattern. They will read just the pattern, not the discussion. Fearless change discussions are part of the pattern. But there should be appropriate introductions. Stories should be part of the pattern or people won't read them.
+    – m: We should add a disclaimer page to the book (for now).
+    – b: Creative Commons license should be on each page.
+
+### PLOP
+* b: We should take a few of the best, complete patterns to PLOP or EuroPLOP and see what others outside the InnerSource community are thinking; external feedback.
+
+### Expanding the team
+* O'Reilly InnerSource Patterns webinar?
+    – yes, there is interest if e wants us to push this
+* d: Will watch the Webinar youtube and distribute the links internally to folks interested in this topic
+* b: Some progress can be made with the core that exists
+* k: There should be a surge of interest after the summit
+
+#### Preparations for the Spring Summit
+* m: 2.5 hours: 1.5 hours in morning; 1 hour in the afternoon (break-out session). Will be in touch to talk about how we will organize this.
+* g: might have something to present in Geneva
+* n: Haven't seen the agenda
+
+* In general:
+    – Short InnerSource 101 and 102
+    – Measuring Success
+    – Project Agora
+    – Psychological Safety and Learning
+    – Honeymoon effect
+    – Designing your first experiment
+    – Strategy development workshop
+    –  plus some keynotes, Q&A opportunities
+
+* d: Should have some way to measure the benefit. E.g., provisioning github Enterprise to show the linkages
+    - ISC Spring Summit Agenda: https://tech.ebu.ch/docs/events/innersource17/isc_programme_v1_0.docx.pdf
+
+#### Remaining 40 minutes

--- a/raw-material/Hiring leverages culture-raw-material.md
+++ b/raw-material/Hiring leverages culture-raw-material.md
@@ -1,0 +1,25 @@
+##### k: Early-Idea "Hiring leverages culture" for initial discussion.
+* Hiring HR practices can be benefited from innerSource and open source practices
+* Employee retention too
+* Something outside of the engineering organization, to get other parts of business involved
+* Better quality engineers are active in open source
+* For internal people inside the company
+* some are afraid of it (they may get to learn and like it)
+* some love it (they are more social)
+* todo group is tracking open source office positions (insight into how companies are thinking about people to interact in these ways)
+* Will start a repository listing Jobs that post positions mentioning InnerSource
+* Have you seen this in your companies?
+* Problem statement?
+
+* b: thinking about the software craftsmanship movemenm: open source development being sexy; people asking for your github repository; companies training apprentices. Getting back to the ancient days where people are writing good quality SW rather than just hacking it out. A reaction to waterfalls and to Agile (let's plan it and do it really well and become masters at writing this code). Giving a short talk on this to the TLC in June (internal to our company).
+* g: Our HR isn't using InnerSource in their hiring; but some have said that the only reason they stayed was to participate in InnerSource. And some people switched jobs in my company to continue to work in InnerSource. HR is figuring out ways to make our company more attractive to SW engineers. InnerSource may play a role in that.
+* k: one guy put into their engineering rec positions some blurbs about InnerSource. Some may not even know the term. He put it as "internal open source". Home Away (vacation rentals) have been posting a lot in their job boards about InnerSource. Would be interesting to find someone there to join our group.
+* b: Are you thinking this would go with Hiring? Retention? Or starting a new program?
+* k: Probably hiring and retention.
+* b: You want to hire good employees to stick around for a while.
+* m: There are engineers at our company that have come in with open source experience and prefer to work in that way.
+* g: Talk with xxx; I'm sure they are leveraging InnerSource in their hiring.
+* n: InnerSource as a key component for attracting talent. Some engineers shared that it is a must-have, not a nice-to-have (that there will be code sharing and inner sourcing)
+* k: Millennials are overtaking the job market (majority now)
+* o: This can bring new talents; can also be used to show clients, to bring in new clients (talking about the projects and InnerSource). Open house concepm: bringing in people to tour. People come to me and talk about our InnerSource community. Clients are curious. Many aren't familiar with InnerSource but are fascinated by the concept.
+* b: n, I'll be happy to shepherd your **pattern**

--- a/raw-material/Start as Experiment-additional-raw-material.md
+++ b/raw-material/Start as Experiment-additional-raw-material.md
@@ -1,0 +1,36 @@
+##### g: Start as Experiment InnerSource (proven pattern)
+* Ref: https://github.com/paypal/InnerSourcePatterns/pull/66
+* Contained InnerSource pattern
+* Related to Review Committee
+* Mechanism to kickstart InnerSource
+* Declare InnerSource to be an experiment in the beginning
+* Problem: most managers have no experience with open source methods and don't want to invest people/time/money in it
+* We are traditionally not a SW company (coming from manufacturing); little to no open source.
+* Idea of InnerSource is popular with developers (they are familiar with open source). Many of our products now use open source.
+* The way we sold IS to managers: would increase the efficiency of global development (very few projects only happen in one site). Efficiency is a problem. They want to validate these claims about efficiencies; we don't have numbers yet to support this.
+* If there is a lot of uptake on IS, it would be hard to shut it down (fear)
+* regulatory and legal problems
+* Solutiok: declare it as a time-limited experiment (we did ours for 3 years)
+    – what the outcomes should be
+    – combined with Review Committee pattern (gave management some influence on what was going on)
+* Resulting contexm: managers are willing to kick off InnerSource and fund it
+    - declaring it an experiment relieves the need to scrutinize numbers
+    – saying it could fail makes it easier to sign off on
+    – even in the case of failure, it will be clear that we've learned something useful
+* k: At the three year mark?
+* g: We had no measurements for proposed efficiency gain (2x) but it was very obvious it was beneficial so they continued to fund it (so many benefits).
+* p: How did you know it was successful? Did you have clear KPIs or measurements that indicated it was successful?
+* g: No, not aware of what KPIs were used to show this. I will look for more information on this.
+* p: This reminds me of the Trial Run pattern.
+    – "Trial run" by Mary Lynn Manns and Linda Rising in "Fearless Change" book, p. 245
+* b: Reminds me of many things in Fearless Change (for getting patterns going).
+* g: It has helped us a lot (developers got the right perspective); if you declare it an experiment, it issues a challenge to the developers to make it work.
+* k: Important to classify your type of company. At the last OSCON, I remember hearing: you can do it grass roots or top down.
+* g: I think you need both; if no uptake at developer, top down won't work. If only grass roots, it is also doomed.
+
+* m: Would still like to see the Contained InnerSource pattern written. A way for two product lines to contribute resources to collaboratively write common software (using open source tools and methods).
+* g: The SW is usually not shared with Contained InnerSource. The BU that did this is now joining our platform with 3000 developers--this went all the way up to the Board level. Will work more on this (reopen the PR).
+
+* n: If this is proven, it could be helpful to people. Part of the solution should be to design and communicate criteria for evaluating the experiment. Some data should be included here (proven example).
+* k: Even if qualitative instead of quantitative.
+* g: Okay. I'll add something in there.


### PR DESCRIPTION
This repo's wiki is not really maintained anymore. Hence we should examine it's contents for inclusion into the main repo and deactivate the wiki.

This pull request does exactly that. 
@spier: Please also have a look.