### PR TITLE
Add link checker only for README.md

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+# from: https://github.com/marketplace/actions/link-checker
+
+name: Link Check on README.md
+
+on: push
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Link Checker
+      id: lc
+      uses: peter-evans/link-checker@v1
+      with:
+        args: -v -d . -x http://creativecommons.org/licenses README.md
+    - name: Fail if there were link errors
+      run: exit ${{ steps.lc.outputs.exit_code }}


### PR DESCRIPTION
Adds one check as discussed in #142. 

This introduces a GitHub Action that checks all links in `README.md` on every push. Links are checked using https://github.com/raviqqe/liche.

This will check both local links (files), as well as http links.

If any link isn't reachable, or the filenames linked are wrong, the check will fail and block a PR to be merged into master (assuming that this is how the protection rules for master are configured).

## Implementation Details:

The link to `http://creativecommons.org/licenses/by-sa/4.0/` is ignored by this check, as somehow that returns 521 even though it loads correctly in the browser.

Error response was:

```
	ERROR	http://creativecommons.org/licenses/by-sa/4.0/
		 (HTTP error 521)
```