### PR TITLE
Add Link Checker exception for isc-inviter.herokuapp.com

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,6 @@ jobs:
       id: lc
       uses: peter-evans/link-checker@v1
       with:
-        args: -v -d . -x http://creativecommons.org/licenses README.md
+        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}


### PR DESCRIPTION
I cannot test if this really works, because for whatever reason the link check for isc-inviter.herokuapp.com does not fail for me.