### PR TITLE
Pattern Template: Marking Authors and Acknowledgements as optional

### DIFF
--- a/meta/pattern-template.md
+++ b/meta/pattern-template.md
@@ -29,7 +29,7 @@ What is the situation after the problem has been solved? The original context is
 Explains why this is the right solution; using totally different words WHY this solution balances these forces and this context to solve this problem. Can expand on what-if's or theories.
 
 ## Known Instances (optional)
-Where has this been seen before? Helps to reinforce that this is a REAL pattern and that you match the context
+Where has this been seen before? Helps to reinforce that this is a REAL pattern and that you match the context.
 
 May mention:
 * A particular business
@@ -40,8 +40,8 @@ General pattern status is stored in GitHub's Label tagging - see any pull reques
 
 You might store other related info here, such as review history: "Three of us reviewed this on 2/5/17 and it needs John's expertise before it can go further."
 
-## Author(s)
+## Author(s) (optional)
 Often, this is yourself; If you need to, find someone in the InnerSource Commons to be the nominal author (As Told To); Could also be no-one if you do not want to take on authorship (common with a donut looking for a solution)
 
-## Acknowledgements
+## Acknowledgements (optional)
 Include those who assisted in helping with this pattern - both for attribution and for possible future follow up. Though optional, most patterns should list who helped in their creation.


### PR DESCRIPTION
Marking Authors and Acknowledgements as optional, because based on the description they are.

@lenucksi this might be a super quick one to merge as I don't think there is anything controversial in here.