### PR TITLE
Fixes link to pattern discover-your-innersource.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The below lists all known patterns. They are grouped into four stages of maturit
 * [Contracted Contributor](contracted-contributor.md) - *Associates wanting to contribute to InnerSource are discouraged from doing so by their line management. Relief is provided by formal contracts and agreements.*
 * [Dedicated Community Leader](dedicated-community-leader.md) - *Select people with both communications and technical skills to lead the communities to ensure success in starting an InnerSource initiative.*
 * [Gig Marketplace](gig-marketplace.md) - *Establish a marketplace by creating an intranet website that lists specific InnerSource project needs as "Gigs" with explicit time and skill requirements. This will enable managers to better understand their employee’s time commitment and professional benefits thereby increasing the likelihood of garnering approval to make InnerSource contributions.*
-* [InnerSource License](innersource-license.md) - *Two legal entities that belong to the same organization want to share software source code with each other but they are concerned about the implications in terms of legal liabilities or cross-company accounting. An **InnerSource License** provides a reusable legal framework for the sharing of source code within the organization. This opens up new collaboration options, and makes the rights and obligations of the involved legal entities explicit.* 
+* [InnerSource License](innersource-license.md) - *Two legal entities that belong to the same organization want to share software source code with each other but they are concerned about the implications in terms of legal liabilities or cross-company accounting. An **InnerSource License** provides a reusable legal framework for the sharing of source code within the organization. This opens up new collaboration options, and makes the rights and obligations of the involved legal entities explicit.*
 * [InnerSource Portal](innersource-portal.md) - *Create an intranet website that indexes all available InnerSource project information. This will enable potential contributors to more easily learn about projects that might interest them and for InnerSource project owners to attract an outside audience.*
 * [Praise Participants](praise-participants.md) - *Thank contributors effectively to engender further engagement from them and to encourage others to contribute*
 * [Review Committee](review-committee.md) - *A formal review committee is setup within an org to "officiate" particular inner source projects with resources, etc.*
@@ -56,7 +56,7 @@ possible to either deploy the same service in independent environments with sepa
 
 #### Pattern Ideas (not yet proven; brainstormed)
 
-* [Don't Bother Looking](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/60)
+* [Discover Your InnerSource](discover-your-innersource.md)
 * [Junkyard Styled Inner Sourcing](junkyard-styled-innersourcing.md)
 * [Shared Code Repo Different from Build Repo](shared-code-repo-different-from-build-repo.md) - *Deal with the overhead of having shared code in a separate repository that isn't the same as the project-specific one that is tied to production builds.*
 * [Incentive Alignment](developer-incentive-alignment-for-innersource-contribution.md)

--- a/discover-your-innersource.md
+++ b/discover-your-innersource.md
@@ -1,5 +1,5 @@
 ## Title
-* Discover Your InnerSource
+Discover Your InnerSource
 
 ## Also Known As
 * Not looking for stuff internally
@@ -18,8 +18,8 @@
 * We have similar challenges getting data sources pulled into the search engine. PayPal is building a project called Agora to do this and they are planning to open source it.
 * Github Enterprise and npmjs have built-in searches on meta-data. Enterprise that opts into these tooling will get some of that functi
 * Software component(s) are available internally but users can't easily find these.
-* This problem is more likely to occur where there are silos in the company (e.g., larger companies; smaller companies may have fewer opportunities for reuse of internally developed software). 
-* The company traditionally has been bad at sharing across silos (people don't have the culture of sharing). 
+* This problem is more likely to occur where there are silos in the company (e.g., larger companies; smaller companies may have fewer opportunities for reuse of internally developed software).
+* The company traditionally has been bad at sharing across silos (people don't have the culture of sharing).
 
 ## Problem
 People don't bother looking for internally developed solutions - they might not find the repo at all or be aware of its existence.
@@ -54,7 +54,7 @@ Make it easy to find the reusable code.
 * Developers looking for code can search for it and find it quickly.
 * Developers are now looking internally for software components
 * Search results are combined (internal and external)
-* Process changes, establishing a common communications channel, and encouraging and rewarding owners of reusable code to use the same search engine can contribute to changing the corporate culture. Transformation begins from the grassroots but requires strategic involvement of thought leaders. 
+* Process changes, establishing a common communications channel, and encouraging and rewarding owners of reusable code to use the same search engine can contribute to changing the corporate culture. Transformation begins from the grassroots but requires strategic involvement of thought leaders.
 * See [Improved Findability](improve-findability.md) (aka Poor Naming Conventions or Badly Named Piles) as a related pattern.
 
 ## Status


### PR DESCRIPTION
The PR for this pattern had been merged some time ago, so it makes more sense to link to the markdown, than to the PR. Also the pattern has been renamed in the meantime.