### PR TITLE
Remove links from patterns to wiki pages that don't exist any more

### DIFF
--- a/bad-weather-for-liftoff.md
+++ b/bad-weather-for-liftoff.md
@@ -44,9 +44,3 @@ Donut
 ## Author(s)  
 
 * Georg Grütter, Wyane DuPont, Michael Dorner
-
-## See Also
-
-This pattern was originally created in this wiki and then ported here.
-Original wiki page:
-https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Donut:-Bad-weather-for-liftoff

--- a/change-the-developers-mindset.md
+++ b/change-the-developers-mindset.md
@@ -58,7 +58,3 @@ Old status: Pattern Idea
 ## See Also
 
 This pattern has been moved for discussion at https://github.com/InnerSourceCommons/InnerSourcePatterns/issues/39
-
-This pattern was originally created in this wiki and then ported here.
-Original wiki page:
-https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Pattern:-change-the-developers-mindset

--- a/defeat-hierarchical-constraints.md
+++ b/defeat-hierarchical-constraints.md
@@ -33,9 +33,3 @@ Developers feel empowered to spend at least 20% of their time on inner sourcing
 Donut
 
 ## Author(s)
-
-## See Also
-
-This pattern was originally created in this wiki and then ported here.
-Original wiki page:
-https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Donut-3%3A-how-to-defeat-the-hierarchical-constraints

--- a/developer-incentive-alignment-for-innersource-contribution.md
+++ b/developer-incentive-alignment-for-innersource-contribution.md
@@ -76,9 +76,3 @@ Old status: brainstormed solution
 ## Author   
 
 Jory Burson
-
-## See Also
-
-This pattern was originally created in this wiki and then ported here.
-Original wiki page:
-https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Donut:-Creating-Developer-Incentive-Alignment-for-InnerSource-Contribution

--- a/organizational-mindset-change.md
+++ b/organizational-mindset-change.md
@@ -35,9 +35,3 @@ All of the company heartily adopts inner sourcing! Cake for everyone!
 Donut
 
 ## Author(s)  
-
-## See Also
-
-This pattern was originally created in this wiki and then ported here.
-Original wiki page:
-https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Donut-6:-organizational-mindset-change

--- a/overcome-acquisition-based-silos-developer.md
+++ b/overcome-acquisition-based-silos-developer.md
@@ -74,9 +74,3 @@ Old Status: Pattern Idea - Draft In Progress
 ## Author
 
 David Marcucci, Nicholas Stahl, Padma Sudarsan, Ryan Bellmore, Erin Bank
-
-## See Also
-
-This pattern was originally created in this wiki and then ported here.
-Original wiki page:
-https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Overcome-Acquisition-based-Silos

--- a/overcome-acquisition-based-silos-manager.md
+++ b/overcome-acquisition-based-silos-manager.md
@@ -77,9 +77,3 @@ Old Status: Pattern Idea - Draft In Progress
 ## Author
 
 David Marcucci, Nicholas Stahl, Padma Sudarsan, Ryan Bellmore, Erin Bank
-
-## See Also
-
-This pattern was originally created in this wiki and then ported here.
-Original wiki page:
-https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Overcome-Acquisition-based-Silos

--- a/share-your-code-to-get-more-done.md
+++ b/share-your-code-to-get-more-done.md
@@ -59,9 +59,3 @@ Old status: Idea
 ## Author
 
 David Marcucci
-
-## See Also
-
-This pattern was originally created in this wiki and then ported here.
-Original wiki page:
-https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Pattern:-Share-Your-Code-to-Get-More-Done---Likely-Contributors-Variant

--- a/shared-code-repo-different-from-build-repo.md
+++ b/shared-code-repo-different-from-build-repo.md
@@ -31,9 +31,3 @@ Ideally, overhead is minimized or eliminated. Or integrate the shared code repos
 Unproven
 
 ## Author  
-
-## See Also
-
-This pattern was originally created in this wiki and then ported here.
-Original wiki page:
-https://github.com/InnerSourceCommons/innersourcecommons.org/wiki/Shared-Code-Repo-Different-from-Build-Repo


### PR DESCRIPTION
When we ported wiki pages into markdown files, we created links from the `.md` pattern files to the respective wiki pages. 

Now that those [wiki pages have been deleted](https://github.com/InnerSourceCommons/innersourcecommons.org/issues/134), these links are no longer working, and not needed anymore.

This PR removes these broken links from the `.md` pattern files.