### PR TITLE
Change headlines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# InnerSource Patterns
+
 This repository contains the InnerSource Patterns collected by the [InnerSource Commons][isc-website]. These patterns are InnerSource best practices codified in a specific format to make it easy to understand, evaluate, and reuse them.
 
 Below you find [what a pattern is][gh-what-are-patterns], a [list of known patterns][gh-list-of-patterns], and [how to use these patterns][gh-how-to-use-patterns] in your organization.
@@ -10,18 +12,17 @@ You are already using InnerSource in your company and want to share your ideas a
 [gh-how-to-use-patterns]: https://github.com/InnerSourceCommons/InnerSourcePatterns#how-can-you-use-inner-source-patterns
 [gh-contribute]: https://github.com/InnerSourceCommons/InnerSourcePatterns#how-to-contribute
 
-# Mission Statement
+## Mission Statement
 
 Our mission in this working group
 - Collect and document agreed upon best practices of how to do InnerSource - in the form of patterns
 - Continuously publish the most mature patterns as an ebook
 
-
-# List of Patterns
+## List of Patterns
 
 The below lists all known patterns. They are grouped into four stages of maturity.
 
-#### Reviewed Patterns (proven and reviewed)
+### Reviewed Patterns (proven and reviewed)
 
 * [30 Day Warranty](30-day-warranty.md) - *a pattern for getting a reluctant code-owning team to accept code submissions from outside their team.*
 * [Common Requirements](common-requirements.md) - *Common code in a shared repository isn't meeting the needs of all the project-teams that want to use it; this is solved through requirements alignment and refactoring.*
@@ -36,12 +37,12 @@ The below lists all known patterns. They are grouped into four stages of maturit
 possible to either deploy the same service in independent environments with separate escalation chains in the event of service downtime or factor a lot of shared code out into one library and collaborate on that.*
 * [Trusted Committer](project-roles/trusted-committer.md) - *Many inner-source projects will find themselves in a situation where they consistently receive feedback, features, and bug-fixes from contributors. In these situations project maintainers seek ways to recognize and reward the work of the contributor above and beyond single contributions.*
 
-#### Reviewed Pattern Ideas (not yet proven but reviewed)
+### Reviewed Pattern Ideas (not yet proven but reviewed)
 
 * [Modular Code](modular-code.md) - *Management does not want to spend the extra resources needed to develop modular components and make them available in a visible repository for others to use.*
 * [Improve Findability](improve-findability.md) - *People can't find the internally developed solutions that they need due to poor naming conventions. This causes frustration in finding inner source solutions and a reduction in code reuse.*
 
-#### Pattern Drafts (proven, not yet fully reviewed)
+### Pattern Drafts (proven, not yet fully reviewed)
 
 * [Assisted Compliance](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/74) - *Helping repo owners be compliant by writing their CONTRIBUTING.md for them as a pull request.*
 * [Cross-Team Project Valuation](crossteam-project-valuation.md) - *It's hard to sell the value of cross-team, inner sourced projects that don't provide a direct impact on company revenue. Here's a data-driven way to represent your project that both articulates its value and amplifies it.*
@@ -54,7 +55,7 @@ possible to either deploy the same service in independent environments with sepa
 * [Start as Experiment](start-as-experiment.md) - *An inner source initiative is considered but not started, because management is unsure about its outcome and therefore unwilling to commit to the investment.*
 * [Include Product Owners](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/71) - *Key Performance Indicators (KPIs) for Product Owners are primarily product focused, and don't consider areas such as collaborative development. This results in a lower level of engagement with inner source projects.*
 
-#### Pattern Ideas (not yet proven; brainstormed)
+### Pattern Ideas (not yet proven; brainstormed)
 
 * [Discover Your InnerSource](discover-your-innersource.md)
 * [Junkyard Styled Inner Sourcing](junkyard-styled-innersourcing.md)
@@ -64,7 +65,7 @@ possible to either deploy the same service in independent environments with sepa
 * [Share Your Code to Get More Done - Likely Contributors Variant](share-your-code-to-get-more-done.md)
 * [Introducing Metrics in InnerSource](introducing-metrics-in-innersource.md) - *Involve all stakeholders in designing and interpreting metrics to measure the current status in terms of health and performance of the InnerSource initiative.*
 
-#### Pattern Donuts (needing a solution)
+### Pattern Donuts (needing a solution)
 
 * [How to Defeat the Hierarchical Constraints](defeat-hierarchical-constraints.md)
 * [Project Management Time Pressures](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/47)
@@ -73,8 +74,7 @@ possible to either deploy the same service in independent environments with sepa
 * [Bad Weather For Liftoff](bad-weather-for-liftoff.md)
 * [Get Contributions Despite Silo Thinking](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/38)
 
-
-# What are InnerSource Patterns?
+## What are InnerSource Patterns?
 
 Patterns are a way of describing a repeatable, proven solution to a problem with a context. They follow a simple form that helps people wanting to implement the solution to understand the constraints on the problem, the forces that must be balanced and the resulting context (the situation you are left with after the solution is applied). In inner sourcing, patterns can provide a way for the InnerSource Commons participants to concisely share information with each other, improving the practice of inner sourcing. Each of the patterns are divided into Title, Problem Statement, Context, Forces, and Solutions as their main sections.
 
@@ -83,14 +83,13 @@ Patterns are a way of describing a repeatable, proven solution to a problem with
 * [Pattern Template File](meta/pattern-template.md) - View a skeleton inner source pattern to get an idea on what goes into a new pattern!
 * [Introduction to InnerSource Patterns (2016 Fall Summit presentation)](https://drive.google.com/open?id=0B7_9iQb93uBQbnlkdHNuUGhpTXc) - *Tim Yao and Padma Sudarsan* (PDF). Detailed pattern background and examples -- Get a detailed understanding of why and how to interact with our patterns. Also see the [Introduction to InnerSource Patterns (2017 Fall Summit)](https://drive.google.com/open?id=0B7_9iQb93uBQWmYwMFpyaGh4OFU) *Tim Yao and Bob Hanmer* (PDF).
 
-# How can you use InnerSource Patterns?
+## How can you use InnerSource Patterns?
 
 Patterns must be used in a thoughtful manner. They cannot be blindly applied. In most cases, you will need to adapt the given solution to your own situation; but the information given in the pattern, defining the context (immovable constraints) and forces (constraints that can be changed and balanced against each other), should help you do this. Note that you will also need to determine if there are additional constraints (company context and company forces) that apply to your particular company/organization that must be added to the pattern (as a kind of filter). These additional constraints may require additional solution steps to be applied.
 
 The pattern form is useful for describing proven patterns but it can also be used for *brainstorming solutions* where patterns are not yet established, since the form gives a structured way for thinking about a problem. You could also create a *donut pattern* (filling in the problem, context, forces and resulting context fields but leaving the solution blank) as a way of asking the InnerSource Commons community for help (to find a proven solution or to brainstorm things to try).
 
-
-# How to Contribute?
+## How to Contribute?
 
 See our [CONTRIBUTING.md](CONTRIBUTING.md) for details on getting involved. To learn how we define, operate, and upkeep this collection of patterns, take a look at [Pattern Meta Info](./meta).
 
@@ -98,12 +97,11 @@ We encourage beginners seeking answers to jump in by creating **donuts** (proble
 
 We work together via Github, Webex, Slack, etc. Do not hesitate to join the [#innersourcecommons](https://isc-inviter.herokuapp.com/) or #innersource-patterns slack channels and ask to be included in the [patterns meetings](/meta/meetings.md) (there is an email list).
 
-
-# Related References
+## Related References
 
 * [A pattern language for pattern writing](http://hillside.net/index.php/a-pattern-language-for-pattern-writing), Meszaros and Doble
 
-# Licensing
+## Licensing
 
 ![Creative Commons License](https://i.creativecommons.org/l/by-sa/4.0/88x31.png)
 


### PR DESCRIPTION
I noticed that the main `README.md` does not have a title. This PR fixes this, and other issues related to headlines.

- add title to README
- reduce level of other headlines accordingly (all go one level down)
- change to one-level decrease per step
- remove some superfluous newlines