### PR TITLE
Adds 2 Patlets to the overview in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ possible to either deploy the same service in independent environments with sepa
 * [Open Source Trumps InnerSource](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/46) - *People find the InnerSource project but, after all things are considered, even if the InnerSource component meets their needs, they still go with the open source component.*
 * [Start as Experiment](patterns/2-structured/start-as-experiment.md) - *An inner source initiative is considered but not started, because management is unsure about its outcome and therefore unwilling to commit to the investment.*
 * [Include Product Owners](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/71) - *Key Performance Indicators (KPIs) for Product Owners are primarily product focused, and don't consider areas such as collaborative development. This results in a lower level of engagement with inner source projects.*
-* [Provide standard base documentation through a README](patterns/2-structured/project-setup/base-documentation.md)
-* [Issue tracker use cases](patterns/2-structured/project-setup/issue-tracker.md)
+* [Provide standard base documentation through a README](patterns/2-structured/project-setup/base-documentation.md) - *New contributors to an InnerSource project have a hard time figuring out who maintains the project, what to work on, and how to contribute. Providing documentation in standard files like README.md/CONTRIBUTING.md enables a self service process for new contributors, so that they can find the answers to the most common questions on their own.*
+* [Issue tracker use cases](patterns/2-structured/project-setup/issue-tracker.md) - *The InnerSource host team fails to make not only plans and progress but also context for changes transparent. This is solved by increasing the use cases for the project issue tracker to also serve brainstorming, implementation discussion, and feature design.*
 
 ### Maturity Level 1: Initial
 

--- a/patterns/2-structured/project-setup/issue-tracker.md
+++ b/patterns/2-structured/project-setup/issue-tracker.md
@@ -4,7 +4,7 @@ Issue tracker use cases
 
 # Patlet
 
-The InnerSource host team fails to make not only plans and progress but also context for changes transparent. This is solved by increasing the use cases for the project issue tracker to also serve brainstorming, implemenation discussion, and feature design.
+The InnerSource host team fails to make not only plans and progress but also context for changes transparent. This is solved by increasing the use cases for the project issue tracker to also serve brainstorming, implementation discussion, and feature design.
 
 # Context
 
@@ -90,4 +90,3 @@ development but also during the planning phase of new features:
 # Status
 
 Proven
-


### PR DESCRIPTION
Adds 2 Patlets to the overview in the README. Makes it easier for readers to scan the patterns quickly.

Affected patterns:
- Provide standard base documentation through a README
- Issue tracker use cases

Also fixes a minor typo.