### PR TITLE
Cleaning up overview of the meta info. 

### DIFF
--- a/meta/README.md
+++ b/meta/README.md
@@ -3,13 +3,12 @@
 The topics below cover information about how we define, operate, and upkeep this collection of patterns.
 
 * [Pattern Template](./pattern-template.md) - Start a new pattern with a copy of this
-* [Pattern States](./pattern-states.md) - Definitions of the various states and review steps a pattern can be in
-* [Pattern System](./pattern-system.md) (draft) For a human reader it is not easy to digest a long list of patterns. We are working on labeling and classifying the patterns further. See [Pattern System](pattern-system.md) for our current thoughts.
+* [Contributor Handbook](./pattern-states.md) - Lays out a basic guideline of how to write and contribute a new pattern, including the 3 maturity levels for patterns.
+* **(draft)** [Pattern System](./pattern-system.md) - For a human reader it is not easy to digest a long list of patterns. We are working on labeling and classifying the patterns further.
 * [Trusted Committers](../TRUSTED-COMMITTERS.md) - Who these people are, what elevated rights they get, and how you can become one
-* [Publishing](./publishing.md) - How we take completed, reviewed, proven patterns and publish them toward an online book
 * [Markdown Info](./markdown-info.md) - Markdown is the ascii text format our patterns are written in; this document briefly defines how we use it
 * [Contributing](../CONTRIBUTING.md) - How to interact with our group, create your own patterns, or take part in our review-process; Github / Web centric instructions
   * [Alternate Command-line steps](./technical-git-howto.md) - If you want to contribute a pattern using `git` from the command-line, this is your document
-  * [Meetings](./meetings.md) - Become involved with the people and communications of the Inner Source Patterns group
 * **(incomplete) Writing Guidelines** - To make the writing for our patterns more consistent, we provide some guidelines to help the various authors to keep a consistent voice.
   * [InnerSource Spelling](./innersource-spelling.md) - Clarifies the mystery around how to spell this. Spoiler: It is **InnerSource**.
+* [FAQ](./FAQ.md) - Frequently asked questions about InnerSource Patterns

--- a/meta/README.md
+++ b/meta/README.md
@@ -3,7 +3,7 @@
 The topics below cover information about how we define, operate, and upkeep this collection of patterns.
 
 * [Pattern Template](./pattern-template.md) - Start a new pattern with a copy of this
-* [Contributor Handbook](./pattern-states.md) - Lays out a basic guideline of how to write and contribute a new pattern, including the 3 maturity levels for patterns.
+* [Contributor Handbook](./contributor-handbook.md) - Lays out a basic guideline of how to write and contribute a new pattern, including the 3 maturity levels for patterns.
 * **(draft)** [Pattern System](./pattern-system.md) - For a human reader it is not easy to digest a long list of patterns. We are working on labeling and classifying the patterns further.
 * [Trusted Committers](../TRUSTED-COMMITTERS.md) - Who these people are, what elevated rights they get, and how you can become one
 * [Markdown Info](./markdown-info.md) - Markdown is the ascii text format our patterns are written in; this document briefly defines how we use it


### PR DESCRIPTION
Cleaning up the overview of the files kept in the `/meta` folder.

* Removed links to deleted files - `publishing.md`, `meetings.md`, `pattern-states.md`
* Added missing files - `contributor-handbook.md`, `FAQ.md` 
* Simplified wording for the Pattern System

## Open Questions 

This is more food for thought. If you are happy to review this PR as is, please do.

* It seems like a lot? I wonder which of the files are actually used by contributors?
* `CONTRIBUTING.md` and `contributor-handbook.md` seem a bit redundant when you see them listed here in the overview. However the files do contain quite different information. I wonder if we could merge them?
