### PR TITLE
Fix links between patterns

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,6 @@ jobs:
       id: lc
       uses: peter-evans/link-checker@v1
       with:
-        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md -r patterns/2-structured/*
+        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md -r patterns/2-structured/* -r patterns/3-validated/* -r patterns/1-initial/*
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,6 @@ jobs:
       id: lc
       uses: peter-evans/link-checker@v1
       with:
-        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md
+        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md patterns/2-structured/*
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,6 @@ jobs:
       id: lc
       uses: peter-evans/link-checker@v1
       with:
-        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md -r patterns/2-structured/* -r patterns/3-validated/* -r patterns/1-initial/*
+        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md patterns/ -r
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 # from: https://github.com/marketplace/actions/link-checker
+# link checker used is 'liche': https://github.com/raviqqe/liche
 
 name: Link Check on README.md
 
@@ -12,6 +13,6 @@ jobs:
       id: lc
       uses: peter-evans/link-checker@v1
       with:
-        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md patterns/2-structured/*
+        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md -r patterns/2-structured/*
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,6 @@ jobs:
       id: lc
       uses: peter-evans/link-checker@v1
       with:
-        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com" README.md patterns/ -r
+        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com|https://github.com/rcs/rcs-viewer/pull/81" README.md patterns/ -r
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 The goal of the InnerSource patterns working group is to collect, document, and publish InnerSource best practices. To make the best practices easy to comprehend, evaluate, and apply, we codify them in a specific structure - [the patterns format](meta/pattern-template.md). More infos on the working group can be found in our [README.md](README.md) file.
 
-For this working group to strive, we welcome your contribution - be it small or huge. 
+For this working group to strive, we welcome your contribution - be it small or huge.
 
 
 ## How to Contribute?
@@ -31,7 +31,7 @@ We are happy to support you in contributing to the InnerSource patterns or to ju
 
 ## License of Contributions
 
-The contents of this repository are licensed under [CC-BY-SA-4.0](LICENSE.md). By contributing to this repository, you grant us (and everyone else for that matter) the right to use your contribution in accordance with that license.
+The contents of this repository are licensed under [CC-BY-SA-4.0](LICENSE.txt). By contributing to this repository, you grant us (and everyone else for that matter) the right to use your contribution in accordance with that license.
 
 
 ## Code of Conduct

--- a/meta/innersource-spelling.md
+++ b/meta/innersource-spelling.md
@@ -10,7 +10,7 @@ We encourage you to use the word as a proper noun (like “We use InnerSource in
 
 We favor the spelling **InnerSource**, for the following reasons:
 
-1. That’s the way Tim O’Reilly [spelled it in 2000][opengl_1200] (he was into Perl and camel-case was a thing). Also see the [Foreword of the Adopting InnerSource book](foreword_AdoptingInnerSource) for more of Tim O’Reilly's own words on the topic. 
+1. That’s the way Tim O’Reilly [spelled it in 2000][opengl_1200] (he was into Perl and camel-case was a thing). Also see the [Foreword of the Adopting InnerSource book][foreword_AdoptingInnerSource] for more of Tim O’Reilly's own words on the topic. 
 2. If you set up side-by-side Google searches for “Inner Source” and “InnerSource” you will find that you get more hits on the former term, by only 1% of them have anything to do with what we call InnerSource. The latter term will be 100% cogent to your inquiry.
 3. The OSI was [denied trademark on the term “open source”][no-open-source-trademark] because it was made up of two common and unrelated terms. “InnerSource” on the other hand is a new word.
 

--- a/meta/markdown-info.md
+++ b/meta/markdown-info.md
@@ -2,7 +2,7 @@
 
 A markdown file is a plain ASCII text file that is meant to be easy to read in plaintext, while also being pretty once rendered.
 
-It is similar to the format that many wiki's have. As an example, you can see [this rendered pattern](../dedicated-community-leader.md) of ours also [in plain text](/../../raw/master/dedicated-community-leader.md). You can do this for any markdown file by clicking the ``Raw`` button when viewing a file online.
+It is similar to the format that many wiki's have. As an example, you can see [this rendered pattern](../patterns/2-structured/dedicated-community-leader.md) of ours also [in plain text](/../../raw/master/patterns/2-structured/dedicated-community-leader.md). You can do this for any markdown file by clicking the ``Raw`` button when viewing a file online.
 
 The ASCII is marked up in a standard format. Here are two cheatsheets for that format:
 

--- a/meta/technical-git-howto.md
+++ b/meta/technical-git-howto.md
@@ -1,6 +1,6 @@
 # Command-line git steps for creating a new Pattern
 
-If you want to contribute a new pattern, the workflow is done through Branches and Pull Requests (PR's). You can see the available branches on [the branches URL](https://github.com/InnerSourceCommons/InnerSourcePatterns/branches/all) and existing PR's on the [Pull Request page](https://github.com/InnerSourceCommons/InnerSourcePatterns/pulls). Branches are meant to separate content, so that multiple people can work all at once. Pull Requests (PR's) are used to bring discussion/review about a specific inner source pattern. 
+If you want to contribute a new pattern, the workflow is done through Branches and Pull Requests (PR's). You can see the available branches on [the branches URL](https://github.com/InnerSourceCommons/InnerSourcePatterns/branches/all) and existing PR's on the [Pull Request page](https://github.com/InnerSourceCommons/InnerSourcePatterns/pulls). Branches are meant to separate content, so that multiple people can work all at once. Pull Requests (PR's) are used to bring discussion/review about a specific inner source pattern.
 
 There are indeed multiple ways to start a discussion:
 
@@ -8,7 +8,7 @@ There are indeed multiple ways to start a discussion:
 * Create an Issue and ask for comments from some of the maintainers. You can mention them using the '@' symbol prior to their github nickname.
 * Add reviewers to the Pull Request on the website - this sends requests to review your work
 
-New patterns should use, as their base, the [pattern template file](meta/pattern-template.md). 
+New patterns should use, as their base, the [pattern template file](pattern-template.md).
 
 Please, when starting a new pattern, make sure that it does not already exist. Take a look at some of the [existing patterns in this repository](/README.md#reviewed-patterns-proven-and-reviewed).
 
@@ -69,7 +69,7 @@ branch with a new pattern named as foo should be as follows:
 $ git checkout -b pattern/foo
 ```
 
-You are now in the 'pattern/foo' branch. When you create a new branch, the files 
+You are now in the 'pattern/foo' branch. When you create a new branch, the files
 in the directory might appear to have changed. Each branch can have slightly different content, and that is intentional. If you need to go back to the 'master' branch or another branch, you can easily 'checkout' to those as follows:
 
 ```
@@ -87,7 +87,7 @@ $ git checkout -b pattern/ewoks-do-not-hunt
 $ touch ewoks-do-not-hunt.md
 ```
 
-You can fill your [markdown](meta/markdown-info.md) file with the [pattern template text](meta/pattern-template.md) and begin to fill it in with your pattern.
+You can fill your [markdown](markdown-info.md) file with the [pattern template text](pattern-template.md) and begin to fill it in with your pattern.
 
 Once our pattern file is ready to go, we need to add the file to the repo and
 commit that change to our new branch.

--- a/patterns/2-structured/30-day-warranty.md
+++ b/patterns/2-structured/30-day-warranty.md
@@ -79,4 +79,4 @@ Drafted at the 2017 Spring InnerSource Summit; reviewed 18 July 2017.
 ## Variants
 
 - Ensure cooperation of dependent teams by making them a community by having
-  more than one, meritocratically appointed "[Trusted Committers](project-roles/trusted-committer.md)" (TCs) take responsibility.
+  more than one, meritocratically appointed "[Trusted Committers](./trusted-committer.md)" (TCs) take responsibility.

--- a/patterns/2-structured/contracted-contributor.md
+++ b/patterns/2-structured/contracted-contributor.md
@@ -111,7 +111,7 @@ empowering middle management to sign off on it:
 A formal contracting is also beneficial for contributors and communities:
 
 - With a stable group of contributors, it is more likely that some of them will
-  eventually achieve [Trusted Committer](project-roles/trusted-committer.md) status.
+  eventually achieve [Trusted Committer](./trusted-committer.md) status.
 - A formal contracting provides a basis for resolving conflict related to
   participation in InnerSource activities. Note that mediation will likely be
   successful only for a few companies with a culture condusive to that.

--- a/patterns/2-structured/praise-participants.md
+++ b/patterns/2-structured/praise-participants.md
@@ -12,7 +12,7 @@ Praise and thanks are easy, affordable ways to keep contributors and their manag
 A pattern in this area makes it easy to do and ensures that the message comes across clearly and sincerely.
 
 ## Context
-* You are the [Trusted Committer](project-roles/trusted-committer.md) or maintainer on an inner source project.
+* You are the [Trusted Committer](./trusted-committer.md) or maintainer on an inner source project.
 * You value the community of contributors and want to maintain and grow it.
 
 ## Forces

--- a/patterns/2-structured/praise-participants.md
+++ b/patterns/2-structured/praise-participants.md
@@ -52,7 +52,7 @@ Overdoing it may feel insincere and mechanical and defeat your purpose in reachi
 
 ## Related Patterns
 
-* _Just Say Thanks_ (from the book [_Fearless Change_](http://www.fearlesschangepatterns.com/))
+* _Just Say Thanks_ (from the book [_Fearless Change_](https://fearlesschangepatterns.com/))
 
 ## Known Instances
 

--- a/patterns/2-structured/start-as-experiment.md
+++ b/patterns/2-structured/start-as-experiment.md
@@ -91,7 +91,7 @@ of success.
 ## Related Patterns
 
 - _Trial Run_ (from the book [_Fearless
-  Change_](http://www.fearlesschangepatterns.com/))
+  Change_](https://www.fearlesschangepatterns.com/))
 
 ## Known Instances
 

--- a/patterns/2-structured/start-as-experiment.md
+++ b/patterns/2-structured/start-as-experiment.md
@@ -44,8 +44,8 @@ or are actively developing Open Source software.
 
 Declare the InnerSource initiative as a time limited experiment. Define and
 communicate the criteria for projects to join the InnerSource experiment. Choose
-criteria that will maximize the chances of building a healthy A set of criteria is 
-a good one if the insights generated from it within the context of the experiment 
+criteria that will maximize the chances of building a healthy A set of criteria is
+a good one if the insights generated from it within the context of the experiment
 can intuitively be applied to contexts involving other potential InnerSource projects.
 Examples for such criteria are:
 
@@ -60,7 +60,7 @@ point to re-evaluate. Also consider establishing a [Review
 Committee](review-committee.md) to increase the chances of management buy-in
 through participation. Depending on company culture, it might be helpful to
 accompany the experiment with appropriate metrics [First Steps With
-Metrics](introducing-metrics-in-innersource.md). If the projects in the
+Metrics](../1-initial/introducing-metrics-in-innersource.md). If the projects in the
 experiment don't provide a direct impact on the companies revenue, consider
 introducing [Cross Team Valuation](crossteam-project-valuation.md) to highlight
 their value contributions.
@@ -79,7 +79,7 @@ Managers are able to kick start InnerSource for the following reasons:
 - In case of success, the data gathered during the experiment will allow
   managers to make a longer lasting commitment to InnerSource.
 
-Participants in the InnerSource experiment are now conscious that they have to 
+Participants in the InnerSource experiment are now conscious that they have to
 prove to management that InnerSource yields the promised benefits.
 It will therefore help to focus work on those activities which provide the most
 demonstrable value thus increasing the chances of success.

--- a/patterns/2-structured/trusted-committer.md
+++ b/patterns/2-structured/trusted-committer.md
@@ -165,5 +165,5 @@ Published internally at Nike; drafted via pull-request in June of 2018.
 [Loren Sanz]: https://github.com/mrsanz
 [Jeremy Hicks]: https://github.com/greatestusername
 [Noah Cawley]: https://github.com/utanapishtim
-[praise]: /praise-participants.md
+[praise]: ./praise-participants.md
 [Fernando Freire]: https://github.com/dogonthehorizon


### PR DESCRIPTION
While working on creating a [book out of our patterns](https://github.com/InnerSourceCommons/InnerSourcePatterns/issues/173) I noticed that some reference from one pattern to another pattern were broken. (side note: Maybe we can call these inter-pattern links? :))

That issue was likely introduced when we moved around the patterns into the new maturity structure with the 3 subfolders below `patterns`.

## Fix:

- modified the link check to also check everything in the `patterns` folder.
- manually updated the inter-pattern links to point to the correct files