### PR TITLE
Standardize title section

### DIFF
--- a/meta/pattern-template.md
+++ b/meta/pattern-template.md
@@ -33,10 +33,10 @@ Where has this been seen before? Helps to reinforce that this is a REAL pattern 
 
 May mention:
 * A particular business
-* Anonymized instances ex: "3 companies have proven that this is a good solution" or "A large financial services org...". 
+* Anonymized instances ex: "3 companies have proven that this is a good solution" or "A large financial services org...".
 
 ## Status (optional until merging)
-General pattern status is stored in GitHub's Label tagging - see any pull request. Note that this GitHub label tagging becomes less visible once the pattern is finalized and merged, so having some information in this field is helpful. 
+General pattern status is stored in GitHub's Label tagging - see any pull request. Note that this GitHub label tagging becomes less visible once the pattern is finalized and merged, so having some information in this field is helpful.
 
 You might store other related info here, such as review history: "Three of us reviewed this on 2/5/17 and it needs John's expertise before it can go further."
 
@@ -45,3 +45,6 @@ Often, this is yourself; If you need to, find someone in the InnerSource Commons
 
 ## Acknowledgements (optional)
 Include those who assisted in helping with this pattern - both for attribution and for possible future follow up. Though optional, most patterns should list who helped in their creation.
+
+## Alias (optional)
+If this pattern is also known under a different name than what is listed unter **Title**, please list those alternative titles here. e.g. if the pattern is named after the problem it solves, a helpful alias might be one that describes the solution that is applied.

--- a/patterns/2-structured/contracted-contributor.md
+++ b/patterns/2-structured/contracted-contributor.md
@@ -1,6 +1,6 @@
 ## Title
 
-_Contracted Contributor_
+Contracted Contributor
 
 ## Patlet
 Associates wanting to contribute to InnerSource are discouraged from doing so by their line management. Relief is provided by formal contracts and agreements.

--- a/patterns/2-structured/dedicated-community-leader.md
+++ b/patterns/2-structured/dedicated-community-leader.md
@@ -1,10 +1,9 @@
 ## Title
 
-_Dedicated Community Manager_
-
-alternative:_Dedicated Community Leader_
+Dedicated Community Manager
 
 ## Patlet
+
 Select people with both communications and technical skills to lead the communities to ensure success in starting an InnerSource initiative.
 
 ## Problem
@@ -59,6 +58,10 @@ Having excellent and dedicated community leaders is a precondition for the succe
 ## Known Instances
 
 _BIOS at Robert Bosch GmbH_. Note that InnerSource at Bosch was, for the majority, aimed at increasing innovation and to a large degree dealt with internal facing products. This pattern is currently not used at Bosch for lack of funding.
+
+## Alias
+
+Dedicated Community Leader
 
 ## Status
 

--- a/patterns/2-structured/review-committee.md
+++ b/patterns/2-structured/review-committee.md
@@ -1,6 +1,6 @@
 ## Title
 
-_Review Committee_ (aka _Cheese Interface_)
+Review Committee
 
 ## Patlet
 
@@ -41,6 +41,10 @@ Company A wants to introduce its first InnerSource initiative. Most managers in 
 ## Known Instances
 
 BIOS at Robert Bosch GmbH
+
+## Alias
+
+Cheese Interface
 
 ## Status
 


### PR DESCRIPTION
While working on the automation for the book creation, I needed to parse out the pattern titles from the markdown files. 
I realized that some titles are using a different formatting, which makes the parsing harder and the book also looks a tiny bit inconsistent then.

In this PR I change this:
- remove italics from titles
- move aliases for pattern titles to a separate `Alias` section. This gives the pattern one clear **main name**. the aliases could later be used as separate links to the same pattern if we like to do that.

@lenucksi we don't have the "Alias" section header defined in the Pattern template. However I assumed that extra headers are fine to add, as long as they don't contract the other headers. 

Should I add a definition of the "Alias" section to the Pattern template file as well?

