### PR TITLE
Updated reference implementation (initial value, description bonus)

### DIFF
--- a/patterns/2-structured/repository-activity-score.md
+++ b/patterns/2-structured/repository-activity-score.md
@@ -55,9 +55,10 @@ Manual adjustments according to soft KPIs (see [Forces](#forces)) can be made on
 ``` javascript
 // calculate a virtual InnerSource score from stars, watches, commits, and issues
 function calculateScore(repo) {
-    // weighting:
-    // forks and watches count most, then stars, add some little score for open issues, too
-    let iScore = 1 + repo["forks_count"] * 5 + repo["watchers_count"] + repo["stargazers_count"] / 3 + repo["open_issues_count"] / 5;
+    // initial score is 50 to give active repos with low GitHub KPIs (forks, watchers, stars) a better starting point
+    let iScore = 50;
+    // weighting: forks and watches count most, then stars, add some little score for open issues, too
+    iScore += repo["forks_count"] * 5 + repo["watchers_count"] + repo["stargazers_count"] / 3 + repo["open_issues_count"] / 5;
     let iDaysSinceLastUpdate = (new Date().getTime() - new Date(repo.updated_at).getTime()) / 1000 / 86400;
     // updated in last 3 months: adds a bonus multiplier between 0..1 to overall score (1 = updated today, 0 = updated more than 100 days ago)
     iScore = iScore * (1 + (100 - Math.min(iDaysSinceLastUpdate, 100)) / 100);
@@ -76,14 +77,16 @@ function calculateScore(repo) {
     iBoost *= (365 - Math.min(iDaysSinceCreation, 365)) / 365;
     // add boost to score
     iScore += iBoost;
+    // give projects with a meaningful description a static boost of 50
+    iScore += (repo["_InnerSourceMetadata"]["description"].length > 30 || repo["_InnerSourceMetadata"] && repo["_InnerSourceMetadata"]["motivation"].length > 30 ? 50 : 0);
     // give projects with contribution guidelines (CONTRIBUTING.md) file a static boost of 100
     iScore += (repo["_InnerSourceMetadata"] && repo["_InnerSourceMetadata"]["guidelines"] ? 100 : 0);
     // build in a logarithmic scale for very active projects (open ended but stabilizing around 5000)
     if (iScore > 3000) {
         iScore = 3000 + Math.log(iScore) * 100;
     }
-    // final score is a rounded value starting from 0
-    iScore = Math.round(iScore - 1);
+    // final score is a rounded value starting from 0 (subtract the initial value)
+    iScore = Math.round(iScore - 50);
     // add score to metadata on the fly
     repo._InnerSourceMetadata.score = iScore;
     return iScore;


### PR DESCRIPTION
* starts score calculation with 50 instead of 1 to give active projects with low GitHub stats (forks, stars, watches) a little advantage
* gives projects with a meaningful description (>30 chars) a small bonus of 50 to be listed higher than similar projects with no description