### PR TITLE
Add link to reference implementation (project portal open source project)

### DIFF
--- a/patterns/2-structured/innersource-portal.md
+++ b/patterns/2-structured/innersource-portal.md
@@ -34,7 +34,9 @@ Your organization is interested in adopting an InnerSource work style and InnerS
 
 ## Solutions
 
-Create an InnerSource Portal intranet website where InnerSource project owners can easily advertise the availability of their projects.
+Create an InnerSource Portal intranet website where InnerSource project owners can easily advertise the availability of their projects. 
+
+A [reference implementation](http://github.com/sap/project-portal-for-InnerSource) for implementing this pattern is available on GitHub and open for contributions. It Lists all InnerSource projects of a company in an interactive and ease to use way. Projects can self-register using a dedicated GitHub topic and provide additional metadata.
 
 Visitors to the InnerSource portal should be able to see all available projects as well as search for specific projects based on various criteria such as project name, technologies in use, contributor names, sponsoring business unit etc.  The information displayed via the InnerSource portal should be under the full control of the InnerSource project owners at all times.  Preferably, by sourcing this information directly from a specific data file or meta-data stored in the project repository itself.  Project owners should include all relevant information concerning their projects within those data files including the project name, trusted contributors names, a brief description and links to the code repository or any supporting documentation.  
 
@@ -47,7 +49,7 @@ The InnerSource Portal has enabled InnerSource project owners to advertise their
 ## Known Instances
 
 * A large financial services organization has used the creation of an InnerSource Portal to provide a mechanism of advertising and discovering InnerSource projects in existence across different business units
-* SAP promotes InnerSource projects in the InnerSource portal - projects can self-register using GitHub topics. The [Repository Activity Score](repository-activity-score.md) defines the default order of the InnerSource projects in the portal. Also see [Michael Graf & Harish B (SAP) at ISC.S11 - The Unexpected Path of Applying InnerSource Patterns](https://www.youtube.com/watch?v=6r9QOw9dcQo&list=PLCH-i0B0otNQZQt_QzGR9Il_kE4C6cQRy&index=6).
+* SAP promotes InnerSource projects in the InnerSource portal - projects can self-register using GitHub topics. The [Repository Activity Score](repository-activity-score.md) defines the default order of the InnerSource projects in the portal. Also see [Michael Graf & Harish B (SAP) at ISC.S11 - The Unexpected Path of Applying InnerSource Patterns](https://www.youtube.com/watch?v=6r9QOw9dcQo&list=PLCH-i0B0otNQZQt_QzGR9Il_kE4C6cQRy&index=6). It's codebase is published as a [reference implementation](http://github.com/sap/project-portal-for-InnerSource) and open for contributions.
 * American Airlines promotes InnerSource projects via an [internal InnerSource Marketplace](https://tech.aa.com/2020-10-30-innersource/). Similarly to SAP, projects self-register by adding `innersource` as a GitHub topic. Projects are searchable and filterable by language, topics, number of open issues, etc.
 * The InnerSource Portal pattern has been proven to work extremely well with the associated InnerSource Gig Marketplace pattern in this context
 

--- a/patterns/2-structured/innersource-portal.md
+++ b/patterns/2-structured/innersource-portal.md
@@ -36,7 +36,7 @@ Your organization is interested in adopting an InnerSource work style and InnerS
 
 Create an InnerSource Portal intranet website where InnerSource project owners can easily advertise the availability of their projects. 
 
-A [reference implementation](http://github.com/sap/project-portal-for-InnerSource) for implementing this pattern is available on GitHub and open for contributions. It Lists all InnerSource projects of a company in an interactive and ease to use way. Projects can self-register using a dedicated GitHub topic and provide additional metadata.
+A [reference implementation](http://github.com/sap/project-portal-for-InnerSource) for this pattern is available on GitHub and open for contributions. It lists all InnerSource projects of a company in an interactive and easy to use way. Projects can self-register using a dedicated GitHub topic and provide additional metadata.
 
 Visitors to the InnerSource portal should be able to see all available projects as well as search for specific projects based on various criteria such as project name, technologies in use, contributor names, sponsoring business unit etc.  The information displayed via the InnerSource portal should be under the full control of the InnerSource project owners at all times.  Preferably, by sourcing this information directly from a specific data file or meta-data stored in the project repository itself.  Project owners should include all relevant information concerning their projects within those data files including the project name, trusted contributors names, a brief description and links to the code repository or any supporting documentation.  
 


### PR DESCRIPTION
SAP's implementation for the InnerSource portal pattern is now open source. This change adds a link and some context to the pattern body. Enjoy ;-)