### PR TITLE
Board Report 2020-12

### DIFF
--- a/meta/boardreports/2020-12.md
+++ b/meta/boardreports/2020-12.md
@@ -59,6 +59,7 @@
 **Status: no changes/updates since last report**
 
 - 24th of April 2020: @lenucksi
+- 11th of December 2020: @spier
 
 ## Committer Diversity
 

--- a/meta/boardreports/2020-12.md
+++ b/meta/boardreports/2020-12.md
@@ -1,0 +1,85 @@
+# InnerSource Patterns WG - Report for Governance Meeting 2020-12
+
+**Reporting Period:** 11/2020 (since [previous report](2020-11.md))
+
+**Important Note:** This report does not contain the activity around the APAC Summit yet, as that falls into the next reporting period.
+
+## Mission
+
+*Briefly describe what your project actually does.*
+
+- Discuss community InnerSource practices and dynamics, collect and document agreed upon best practices of how to do InnerSource - in the form of patterns
+- Continuously publish the most mature patterns as an ebook and website
+
+## Project/Community Status and Health
+
+*Sum up the status and health of your project and community in a few sentences*
+
+**Important Note:** Some interesting activity in the Patterns WG in November 2020, 
+
+- 2 new and new-ish contributor in the reporting period ([@WillemJiang](https://github.com/WillemJiang), [@MelindaMalmgren](https://github.com/MelindaMalmgren))
+- Challenges:
+	- PRs with minor changes stay open for extended periods. This prevents quick incremental quality improvements. This might also demotivate contributors, as giving them a sense of success would be a way to keep them engaged in the project. Examples: [#213](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/213), [#222](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/222), [#230](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/230), [#232](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/232) 
+	- Also the longer a PR stays open, the higher the chances that that PR will go stale i.e. the author does not have time anymore to see the PR through. Examples of said risk are [13 PRs](https://github.com/InnerSourceCommons/InnerSourcePatterns/pulls?q=is%3Apr+is%3Aopen+created%3A%3C2020) that have been created prior to 2020, many even in 2017. Bringing these PRs to a stage where they can either be discontinued (i.e. closed) or approved+merged has proven difficult.
+- Activity and trusted committer diversity is too low to sustain the project in the long run on a high activity level. (Low activity evolution is sustainable.)
+
+## Project Activity
+
+*Describe the overall activity in the project over the reporting period.*
+
+- Great work in categorizing patterns according to where they are most impactful within an InnerSource Program (mindmap). This improves the discoverability of the patterns and helps us to understand to what extent the Patterns are already covering all phases of the full InnerSource lifecycle. - @fwan2000
+- Get [InnerSource Patterns book](https://innersourcecommons.gitbook.io/innersource-patterns/v/book/) ready for demo at the ISC 2020 APAC Summit  - @spier
+- Preparing for presentation at the ISC 2020 APAC Summit: *Level up your InnerSource through Patterns* - @fwan2000, @spier
+- Patterns office-hours concept try out, some success, dual time-zone meeting concept successfully in use in Marketing WG - @lenucksi
+- Continuing to work with the new Maturity levels (initial, structured, validated)
+
+### Pattern-work
+
+* [Merged PRs](https://github.com/InnerSourceCommons/InnerSourcePatterns/pulls?q=is%3Apr+closed%3A2020-11-01..2020-11-30+is%3Amerged+): 5
+	* Pattern work: 3 (Adding American Airlines as a Known Instance to the InnerSource Portal Pattern. Improving existing Known Instances for that same pattern.
+	* Non-pattern work: 2
+* [New PRs created](https://github.com/InnerSourceCommons/InnerSourcePatterns/pulls?q=is%3Apr+created%3A2020-11-01..2020-11-30): 3
+
+## Plans of the Project
+
+*Describe the current plans of the project. Include goals the project is working towards as well as any announcements that should be published through the marketing group.*
+
+**Status: no changes/updates since last report**
+
+- Publish our [first official ebook](https://innersourcecommons.gitbook.io/innersource-patterns/v/book/) of the InnerSource Patterns. Once we do that, let’s announce that through our Marketing WG.
+- Process existing content from pull requests and Google group into our repository
+- Evaluate ideas to further facilitate collection of pattern content (e.g. through automation), channel ongoing discussions into pattern-work and attract more contributors, e.g. by lowering the barriers of entry for them.
+- Onboard further trusted committers
+- Possibly review the current list of trusted committers. Some of them don’t seem to be active anymore (likely they receive a lot of github/email spam from us today).
+
+## Last Committer Addition
+
+*When was the last committer added to the project? A healthy project tends to add new committers regularly. The report should indicate the most recent date on which a committer was added.*
+
+**Status: no changes/updates since last report**
+
+- 24th of April 2020: @lenucksi
+
+## Committer Diversity
+
+*Cover committer diversity in your project. A healthy project should survive the departure of any single contributor or employer of contributors. What are your steps to make sure that people from all regions on the globe can participate in your project without having to be awake at midnight their local time?*
+
+**Status: no changes/updates since last report**
+
+- Focus on asynchronous collaboration in the #innersource-patterns channel
+- Offering of office hours on APAC and EU/Americas friendly timeslots
+- Work towards automation of administration tasks, documentation of processes
+- Have TCs in multiple time zones
+
+## Legal Issues & Other Needs
+
+*Are there any project branding or naming issues, either in the project or externally? Any legal issues? Any infrastructure or strategic needs?*
+
+**Status: no changes/updates since last report**
+
+- None currently, book illustrations will trigger IP compliance requirements.
+- Suggestions welcome on how to attract more contributors.
+
+## Any issues for the Board to act on?
+
+- None

--- a/meta/boardreports/2020-12.md
+++ b/meta/boardreports/2020-12.md
@@ -75,10 +75,10 @@
 
 *Are there any project branding or naming issues, either in the project or externally? Any legal issues? Any infrastructure or strategic needs?*
 
-**Status: no changes/updates since last report**
-
-- None currently, book illustrations will trigger IP compliance requirements.
+- **Google Analytics** - can we use it to track readership statistics for our book? (gitbook.com providers Google Analytics tracking natively)
+- **Custom Domain** for the book: Out of the box, the book will live at `innersourcecommons.gitbook.io/innersource-patterns`. If we want a custom domain e.g. to drive traffic to innersourcecommons.org, we would have to configure the DNS for a custom domain. Not sure what is possible but e.g. something like `patterns.innersourcecommons.org/` or `books.innersourcecommons.org/innersource-patterns`. I don't know who can help with DNS? Maybe Cedric?
 - Suggestions welcome on how to attract more contributors.
+- Legal: None currently, book illustrations will trigger IP compliance requirements.
 
 ## Any issues for the Board to act on?
 

--- a/meta/boardreports/2020-12.md
+++ b/meta/boardreports/2020-12.md
@@ -1,8 +1,8 @@
 # InnerSource Patterns WG - Report for Governance Meeting 2020-12
 
-**Reporting Period:** 11/2020 (since [previous report](2020-11.md))
+**Reporting Period:** 11/2020
 
-**Important Note:** This report does not contain the activity around the APAC Summit yet, as that falls into the next reporting period.
+**Important Note:** This report does not contain the Pattern work at the APAC Summit yet, as that falls into the next reporting period (12/2020).
 
 ## Mission
 
@@ -15,10 +15,8 @@
 
 *Sum up the status and health of your project and community in a few sentences*
 
-**Important Note:** Some interesting activity in the Patterns WG in November 2020, 
-
-- 2 new and new-ish contributor in the reporting period ([@WillemJiang](https://github.com/WillemJiang), [@MelindaMalmgren](https://github.com/MelindaMalmgren))
-- Challenges:
+- 2 new and new-ish contributors in the reporting period ([@WillemJiang](https://github.com/WillemJiang), [@MelindaMalmgren](https://github.com/MelindaMalmgren))
+- Challenges: (same as in the [last report](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/meta/boardreports/2020-11.md#projectcommunity-status-and-health))
 	- PRs with minor changes stay open for extended periods. This prevents quick incremental quality improvements. This might also demotivate contributors, as giving them a sense of success would be a way to keep them engaged in the project. Examples: [#213](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/213), [#222](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/222), [#230](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/230), [#232](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/232) 
 	- Also the longer a PR stays open, the higher the chances that that PR will go stale i.e. the author does not have time anymore to see the PR through. Examples of said risk are [13 PRs](https://github.com/InnerSourceCommons/InnerSourcePatterns/pulls?q=is%3Apr+is%3Aopen+created%3A%3C2020) that have been created prior to 2020, many even in 2017. Bringing these PRs to a stage where they can either be discontinued (i.e. closed) or approved+merged has proven difficult.
 - Activity and trusted committer diversity is too low to sustain the project in the long run on a high activity level. (Low activity evolution is sustainable.)
@@ -28,8 +26,8 @@
 *Describe the overall activity in the project over the reporting period.*
 
 - Great work in categorizing patterns according to where they are most impactful within an InnerSource Program (mindmap). This improves the discoverability of the patterns and helps us to understand to what extent the Patterns are already covering all phases of the full InnerSource lifecycle. - @fwan2000
-- Get [InnerSource Patterns book](https://innersourcecommons.gitbook.io/innersource-patterns/v/book/) ready for demo at the ISC 2020 APAC Summit  - @spier
-- Preparing for presentation at the ISC 2020 APAC Summit: *Level up your InnerSource through Patterns* - @fwan2000, @spier
+- Get [InnerSource Patterns book](https://innersourcecommons.gitbook.io/innersource-patterns/v/book/) ready for demo at the ISC 2020 APAC Summit - @spier
+- Preparing presentation for the ISC 2020 APAC Summit: *Level up your InnerSource through Patterns* - @fwan2000, @spier
 - Patterns office-hours concept try out, some success, dual time-zone meeting concept successfully in use in Marketing WG - @lenucksi
 - Continuing to work with the new Maturity levels (initial, structured, validated)
 
@@ -44,22 +42,19 @@
 
 *Describe the current plans of the project. Include goals the project is working towards as well as any announcements that should be published through the marketing group.*
 
-**Status: no changes/updates since last report**
-
 - Publish our [first official ebook](https://innersourcecommons.gitbook.io/innersource-patterns/v/book/) of the InnerSource Patterns. Once we do that, let’s announce that through our Marketing WG.
 - Process existing content from pull requests and Google group into our repository
 - Evaluate ideas to further facilitate collection of pattern content (e.g. through automation), channel ongoing discussions into pattern-work and attract more contributors, e.g. by lowering the barriers of entry for them.
 - Onboard further trusted committers
-- Possibly review the current list of trusted committers. Some of them don’t seem to be active anymore (likely they receive a lot of github/email spam from us today).
+- Review the current list of trusted committers. Some of them don’t seem to be active anymore and likely receive a lot of github notifcations and emails from us that they don't need. (do we have an offboarding process for TCs?)
+- Level up some patterns to higher maturity levels. e.g. the [InnerSource Portal](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/innersource-portal.md) has multiple known instances and even a reference implementation now, so it could be brought to maturity "Validated" relatively easily.
 
 ## Last Committer Addition
 
 *When was the last committer added to the project? A healthy project tends to add new committers regularly. The report should indicate the most recent date on which a committer was added.*
 
-**Status: no changes/updates since last report**
-
-- 24th of April 2020: @lenucksi
 - 11th of December 2020: @spier
+- 24th of April 2020: @lenucksi
 
 ## Committer Diversity
 

--- a/patterns/2-structured/start-as-experiment.md
+++ b/patterns/2-structured/start-as-experiment.md
@@ -91,7 +91,7 @@ of success.
 ## Related Patterns
 
 - _Trial Run_ (from the book [_Fearless
-  Change_](https://www.fearlesschangepatterns.com/))
+  Change_](https://fearlesschangepatterns.com/))
 
 ## Known Instances
 


### PR DESCRIPTION
A report for the ISC Board about what happened in the InnerSource Patterns Working Group in 11/2020.

The report is due on 2020-12-13, to give the Board enough time to read it.

For the ones that don't know: 
It's not that the ISC Board is controlling what we are doing in the Patterns WG. The report is mostly meant for us to inspect regularly how we are doing, and if there is anything that the Board can help us with. So while "report" certainly sounds a bit bureaucratic, is isn't meant to be ;-)