### PR TITLE
Fix failing checks & GitHub Actions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,7 +1,6 @@
 name: Book ToC Generation
 
 on:
-  pull_request:
   push:
     branches:
       - "master"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,6 @@ jobs:
       id: lc
       uses: peter-evans/link-checker@v1
       with:
-        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com|https://github.com/rcs/rcs-viewer/pull/81" README.md patterns/ -r
+        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com|https://github.com/rcs/rcs-viewer/pull/81|fearlesschangepatterns.com" README.md patterns/ -r
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,8 @@
 
 name: Link Check on Patterns and README
 
-on: [push, pull_request]
+on: push
+
 jobs:
   linkChecker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Multiple issues with the failing checks:

* failing Link Check
   * Excluding fearlesschangepatterns.com from link check (in GitHub Action).
   * fearlesschangepatterns keeps failing inconsistently, so Ii am excluding it.
* duplicate link check
   * fixed by removing `pull_request` from the workflow trigger. 
* book ToC Generation triggers even when not on master
   * fixed by removing `pull_request` from the workflow trigger. I hope it will only trigger now when we merge the PR (i.e. push to master)