### PR TITLE
Make LinkChecker GHA work for forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,11 @@
 
 name: Link Check on Patterns and README
 
-on: push
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
 
 jobs:
   linkChecker:


### PR DESCRIPTION
The Link check should run on

a) push to master (when PR is merged)
b) any change to a pull_request