### PR TITLE
Custom linter to check the format of the patterns

### DIFF
--- a/.github/workflows/lint-patterns.yml
+++ b/.github/workflows/lint-patterns.yml
@@ -1,0 +1,24 @@
+# from: https://github.com/marketplace/actions/markdown-linting-action
+
+name: Validate pattern syntax
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  validate-pattern-syntax:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Problem Matcher for markdownlint-cli
+      uses: xt0rted/markdownlint-problem-matcher@v1
+    - name: Lint pattern files (markdown)
+      uses: avto-dev/markdown-lint@v1
+      with:
+        rules: './lint/pattern-template.js'
+        config: './lint/pattern-template.yml'
+        args: 'patterns/2-structured/*.md patterns/2-structured/project-setup/*.md patterns/3-validated/*.md'

--- a/.github/workflows/lint-patterns.yml
+++ b/.github/workflows/lint-patterns.yml
@@ -1,6 +1,5 @@
 # from: https://github.com/marketplace/actions/markdown-linting-action
-
-name: Validate pattern syntax
+name: Pattern Syntax Validation
 
 on:
   push:
@@ -9,11 +8,10 @@ on:
   pull_request:
 
 jobs:
-  validate-pattern-syntax:
+  validate:
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
     - name: Problem Matcher for markdownlint-cli
       uses: xt0rted/markdownlint-problem-matcher@v1
     - name: Lint pattern files (markdown)

--- a/lint/pattern-template.js
+++ b/lint/pattern-template.js
@@ -1,0 +1,115 @@
+"use strict";
+
+module.exports = [
+{
+    names: ["PATTERN-TEMPLATE-RULE-001"],
+    description: "h2 headlines and below",
+    tags: ["headings", "headers", "pattern-template"],
+    function: (params, onError) => {
+        params.tokens.filter(function filterToken(token) {
+            return token.type === "heading_open";
+        }).forEach(function forToken(token) {
+            if (token.tag === "h1") {
+                return onError({
+                    lineNumber: token.lineNumber,
+                    detail: "Use of #-headlines (h1) is not allowed in patterns. Please only use ##-headlines (h2) and lower.",
+                    context: token.line
+                });
+            }
+        });
+    }
+},
+{
+    names: ["PATTERN-TEMPLATE-RULE-002"],
+    description: "Standard Headlines",
+    tags: ["headings", "headers", "pattern-template"],
+    function: (params, onError) => {
+        var allowedHeadlines = "Title|Patlet|Problem|Story|Context|Forces|Solutions|Resulting Context|Known Instances|Status|Author(s)|Acknowledgements";
+        var re = new RegExp(`^## (${allowedHeadlines.replace(/(?=[\(\)])/g, '\\')})\\s*$`,"m");
+        // console.log(re);
+
+        params.tokens.filter(function filterToken(token) {
+            return token.type === "heading_open";
+        }).forEach(function forToken(token) {
+            if (token.tag === "h2") {
+                if (re.test(token.line)) {
+                    return;
+                }
+                // if (/^## ()$/m.test(token.line)) {
+                //     return;
+                // }
+
+                return onError({
+                    lineNumber: token.lineNumber,
+                    detail: "Allowed types are: " + allowedHeadlines.replace(/\|/g, ', '),
+                    context: token.line
+                });
+            }
+        });
+    }
+},
+{
+    names: ["PATTERN-TEMPLATE-RULE-003"],
+    description: "Mandatory template sections",
+    tags: ["headings", "headers", "pattern-template"],
+    function: (params, onError) => {
+        var mandatoryHeadlines = {
+          "Title": "Title",
+          "Patlet": "Patlet",
+          "Problem": "Problem",
+          "Context": "Context",
+          "Forces": "Forces",
+          "Solutions": "Solution|Solutions",
+          "Resulting Context": "Resulting Context",
+          "Known Instances": "Known Instances",
+          "Status": "Status",
+          "Author(s)": "Author|Authors|(Author\\(s\\))"
+        };
+
+        var collectedHeadlines = ""
+
+        // collect all h2 headlines
+        // (only the headline text itself, removing markdown sytnax and whitespace)
+        params.tokens.filter(function filterToken(token) {
+            return token.type === "heading_open";
+        }).forEach(function forToken(token) {
+            if (token.tag === "h2") {
+                let re = new RegExp("^## (.*?)\\s*$","m");
+                let matchResult = token.line.match(re);
+
+                if (matchResult != null) {
+                  collectedHeadlines += matchResult[1] + "\n"
+                }
+            }
+        });
+
+        // confirm if all `mandatoryHeadlines` exist exactly once in the `collectedHeadlines`
+        var errorsFound = [];
+
+        let headline;
+        for (headline in mandatoryHeadlines){
+          let pattern = mandatoryHeadlines[headline];
+          let re = new RegExp(`^${pattern}$`,"gm");
+          let matchResult = collectedHeadlines.match(re);
+
+          // TODO as soon as I use the option 'g' in the regexp, it does not return a full match array anymore
+          if (matchResult != null) {
+              if (matchResult.length >= 2 ) {
+                errorsFound.push(`Duplicate headline "${headline}".`);
+              }
+          }
+          else {
+            errorsFound.push(`Required headline "${headline}" is missing.`);
+          }
+        }
+
+        // if any errors were found, raise a linter error
+        if (errorsFound.length > 0) {
+          return onError({
+              lineNumber: 1,
+              detail: errorsFound.join(" ")
+          });
+        }
+    }
+}
+];

--- a/lint/pattern-template.yml
+++ b/lint/pattern-template.yml
@@ -1,4 +1,4 @@
-default: false # includes/excludes all rules by default
+default: false # excludes all default markdownlint rules
 
 # Custom rules:
 PATTERN-TEMPLATE-RULE-001: true

--- a/lint/pattern-template.yml
+++ b/lint/pattern-template.yml
@@ -1,0 +1,6 @@
+default: false # includes/excludes all rules by default
+
+# Custom rules:
+PATTERN-TEMPLATE-RULE-001: true
+# PATTERN-TEMPLATE-RULE-002: true # will likely stop using this in favor of rule 003
+PATTERN-TEMPLATE-RULE-003: true


### PR DESCRIPTION
This custom markdown linter rules checks the patterns and confirms if all mandatory sections specified in the [Pattern Template](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/meta/pattern-template.md) are present. Implements https://github.com/InnerSourceCommons/InnerSourcePatterns/issues/159.

The checks are only running on patterns of maturity **Structured** (Level 2) and **Validated** (Level 3), but not for **Initial** (Level 1).
This allows patterns of maturity **Initial** to be merged faster, while we apply more scrutiny to the higher levels as they get published in. the book as. well.

The linter, which is executed by a GitHub Action, checks all patterns in these folders:
* `patterns/2-structured/*.md` 
* `patterns/2-structured/project-setup/*.md`
* `patterns/3-validated/*.md`

Luckily the patterns of level 2 and 3 have almost no linter issues anymore. However therefore it is hard to see what the linter would do if any issue exists. To see the linter in action see the bottom of this demo PR:
https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/168/files

FYI the old PR #168 is just kept around for demo purposes and won't be merged.