### PR TITLE
Correctly generate Toc for book if Patlet contains code block

### DIFF
--- a/book/generate_toc.rb
+++ b/book/generate_toc.rb
@@ -39,7 +39,7 @@ def extract_text(node)
   section_nodes = []
   if node.type == :softbreak
     section_nodes << " "
-  elsif node.type == :text
+  elsif node.type == :text or node.type == :code
     section_nodes << node.string_content
   else
     node.each do |subnode|


### PR DESCRIPTION
Fix generation of ToC for book. 
Code blocks are now also turned into regular text.

This fixes a bug that I discovered after adding a `codeblock` to a Patlet here:
https://github.com/InnerSourceCommons/InnerSourcePatterns/commit/08f3d9cc9fc74a5f6c9ada3554b6248fe310a888#diff-1e60bc9708b945b6d43275facd7c543d2da86280b113fdf200f888a533355f36R9

The bug simply removed the codeblock from the ToC completely, rather than turning it into regular text, leading to a faulty text on this page: https://innersourcecommons.gitbook.io/innersource-patterns/toc