### PR TITLE
Add placeholder section, to comply with Pattern Format linter

### DIFF
--- a/patterns/2-structured/common-requirements.md
+++ b/patterns/2-structured/common-requirements.md
@@ -46,6 +46,10 @@ The developers write a story to solve a problem in one way.
 
 The program managers rewrite the story to better express their needs---keeping the essence the same. By the time it returns to developers though they don't recognize it as what they wanted to do in the first place and so balk at implementing it.  The solution to this pattern is to have more seats around the planning table so that story modifications are understood across the project not just in the developer or program manager camps.
 
+## Known Instances
+
+TBD
+
 ## Status
 
 * Structured


### PR DESCRIPTION
Add placeholder section, to comply with Pattern Format linter and prevent broken checks for other PRs.
Follow up to #257.