### PR TITLE
Link to book from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ You are already using InnerSource in your company and want to share your ideas a
 
 ## Mission Statement
 
+<img align="right" src="book/innersource-patterns-book-cover.jpg" width="50%">
+
 Our mission in this working group
 
 - Collect and document agreed upon best practices of how to do InnerSource - in the form of patterns
 - Continuously publish the most mature patterns as an ebook
+
+## The book
+
+We publish the most mature InnerSource Patterns at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/). With "most mature" in this context we mean level 2+3 patterns, as shown below.
 
 ## List of Patterns
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # InnerSource Patterns
 
+<a href="https://innersourcecommons.gitbook.io/innersource-patterns/">
+<img align="right" src="book/innersource-patterns-book-cover.jpg" width="35%"></a>
+
 This repository contains the InnerSource Patterns collected by the [InnerSource Commons][isc-website]. These patterns are InnerSource best practices codified in a specific format to make it easy to understand, evaluate, and reuse them.
 
 Below you find [what a pattern is](#what-are-innersource-patterns), a [list of known patterns](#list-of-patterns), and [how to use these patterns](#how-can-you-use-innersource-patterns) in your organization.
@@ -10,12 +13,10 @@ You are already using InnerSource in your company and want to share your ideas a
 
 ## Mission Statement
 
-<img align="right" src="book/innersource-patterns-book-cover.jpg" width="50%">
-
 Our mission in this working group
 
 - Collect and document agreed upon best practices of how to do InnerSource - in the form of patterns
-- Continuously publish the most mature patterns as an ebook
+- Continuously publish the most mature patterns as an ebook at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/)
 
 ## The book
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # InnerSource Patterns
 
-<a href="https://innersourcecommons.gitbook.io/innersource-patterns/" target="_blank">
+<a href="https://innersourcecommons.gitbook.io/innersource-patterns/">
 <img align="right" src="book/innersource-patterns-book-cover.jpg" title="The InnerSource Patterns book" width="30%"></a>
 
 This repository contains the InnerSource Patterns collected by the [InnerSource Commons][isc-website]. These patterns are InnerSource best practices codified in a specific format to make it easy to understand, evaluate, and reuse them.
 
-If you are here for the first time, we recommend you start by reading our most mature Patterns, published at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/).
+If you are here for the first time, we recommend you start by reading our most mature patterns, published at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/).
 
 Below you find [what a pattern is](#what-are-innersource-patterns), a [list of known patterns](#list-of-patterns), and [how to use these patterns](#how-can-you-use-innersource-patterns) in your organization.
 
@@ -18,7 +18,7 @@ You are already using InnerSource in your company and want to share your ideas a
 Our mission in this working group
 
 - Collect and document agreed upon best practices of how to do InnerSource - in the form of patterns
-- Continuously publish the most mature patterns as an ebook at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/)
+- Continuously publish the most mature patterns as an ebook
 
 ## List of Patterns
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # InnerSource Patterns
 
-<a href="https://innersourcecommons.gitbook.io/innersource-patterns/">
-<img align="right" src="book/innersource-patterns-book-cover.jpg" width="35%"></a>
+<a href="https://innersourcecommons.gitbook.io/innersource-patterns/" target="_blank">
+<img align="right" src="book/innersource-patterns-book-cover.jpg" title="The InnerSource Patterns book" width="30%"></a>
 
 This repository contains the InnerSource Patterns collected by the [InnerSource Commons][isc-website]. These patterns are InnerSource best practices codified in a specific format to make it easy to understand, evaluate, and reuse them.
+
+If you are here for the first time, we recommend you start by reading our most mature Patterns, published at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/).
 
 Below you find [what a pattern is](#what-are-innersource-patterns), a [list of known patterns](#list-of-patterns), and [how to use these patterns](#how-can-you-use-innersource-patterns) in your organization.
 
@@ -17,10 +19,6 @@ Our mission in this working group
 
 - Collect and document agreed upon best practices of how to do InnerSource - in the form of patterns
 - Continuously publish the most mature patterns as an ebook at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/)
-
-## The book
-
-We publish the most mature InnerSource Patterns at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/). With "most mature" in this context we mean level 2+3 patterns, as shown below.
 
 ## List of Patterns
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This repository contains the InnerSource Patterns collected by the [InnerSource Commons][isc-website]. These patterns are InnerSource best practices codified in a specific format to make it easy to understand, evaluate, and reuse them.
 
-If you are here for the first time, we recommend you start by reading our most mature patterns, published at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/).
+If you are here for the first time, you may start by reading our most mature patterns, published at [innersourcecommons.gitbook.io/innersource-patterns](https://innersourcecommons.gitbook.io/innersource-patterns/).
 
 Below you find [what a pattern is](#what-are-innersource-patterns), a [list of known patterns](#list-of-patterns), and [how to use these patterns](#how-can-you-use-innersource-patterns) in your organization.
 


### PR DESCRIPTION
I don't actually know how people find this repo, but I suspect some come via Google searches.

For those of them that are the "learning by reading" type, I suspect that the book would be the better starting point for them. Therefore I want to make it easier for them to find the book.

What I changed:
- adds the book cover image to the README
- links to the book immediate at the top of the README (right after explaining what patterns are in the first place)