### PR TITLE
Reduce unneeded Pattern Syntax check executions

### DIFF
--- a/.github/workflows/lint-patterns.yml
+++ b/.github/workflows/lint-patterns.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - "master"
   pull_request:
+    paths:
+      - ".github/workflows/lint-patterns.yml"
+      - "lint/*"
+      - "patterns/2-structured/*.md"
+      - "patterns/2-structured/project-setup/*.md"
+      - "patterns/3-validated/*.md"
 
 jobs:
   validate:


### PR DESCRIPTION
Improves upon #257.

Limits the executions of this check to PRs that touch Level 2+3 patterns or the config of the Pattern Syntax linter itself
Always runs on `master`, just to be safe.