### PR TITLE
Introducing Hall-of-Fame for former TCs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @lenucksi @nyeates @gruetter @NewMexicoKid @cewilliams @spier
+*       @lenucksi @NewMexicoKid @cewilliams @spier
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only

--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -2,7 +2,7 @@
 
 Trusted Committers (TCs) are those members of our working group who have elevated rights and direct write access to this repository.
 
-> Trusted Committers act as stewards of the working group and community. They aim to make consensus-based decisions in the best interest of the working group. 
+> Trusted Committers act as stewards of the working group and community. They aim to make consensus-based decisions in the best interest of the working group.
 
 They also act as the guardians of this repository: TCs react to, referee, and give feedback about incoming contributions.
 
@@ -17,7 +17,7 @@ For further information about the concept, also see the [Trusted Committer Patte
 
 ## Hall of Fame (aka Alumni)
 
-While Trusted Committers are in principle appointed for lifetime, interests or priorities of a TC can change and they might not have enough time any more to contribute to the project. 
+While Trusted Committers are in principle appointed for lifetime, interests or priorities of a TC can change and they might not have enough time any more to contribute to the project.
 
 In those cases we ask them if we should move them to the Hall of Fame. Doing so allows us to appropriately thank them for all of their fantastic contributions. When doing so we also remove them from `.github/CODEOWNERS`, so that reviews of Pull Requests aren't assigned to them anymore, and GitHub notifications are reduced. That increases the clarity for the community who to expect feedback from when creating PRs.
 
@@ -49,6 +49,6 @@ We follow this process (adapted from [here](https://tech.europace.de/voting-in-n
 
 ## Admins
 
-A handful of individuals are currently the technical GitHub Admins for this repository. This includes most members of the InnerSource Commons' #tech-infra team and members of the [InnerSource Commons GitHub Organization](https://github.com/innersourcecommons). 
+A handful of individuals are currently the technical GitHub Admins for this repository. This includes most members of the InnerSource Commons' #tech-infra team and members of the [InnerSource Commons GitHub Organization](https://github.com/innersourcecommons).
 
 However, please channel working group-specific requests through the trusted committers.

--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -6,10 +6,15 @@ Trusted committers (TCs) are those members of our working group who have elevate
 
 * [@spier](https://github.com/spier) (added 2020-12-11)
 * [@lenucksi](https://github.com/lenucksi) (added 2020-04-24)
-* [@nyeates](https://github.com/nyeates) (added 2017-03-02)
-* [@gruetter](https://github.com/gruetter) (added 2017-03-02)
 * [@NewMexicoKid](https://github.com/NewMexicoKid) (added 2017-03-02)
 * [@cewilliams](https://github.com/cewilliams) (added 2017-03-02)
+
+## Hall of Fame (aka Alumni)
+
+While Trusted Committers are in principal appointed for lifetime, it does happen that the interests or priorities of a TC change and they don't have enough time any more to contribute to the project. In those cases we ask them if we should move them to our Hall of Fame. Doing so allows us to appropriately thank them for all of their fantastic contributions. Of course they can always start contributing again in the future and go back to being Trusted Committers.
+
+* [@gruetter](https://github.com/gruetter) (added 2017-03-02)
+* [@nyeates](https://github.com/nyeates) (added 2017-03-02)
 
 ## Process for Adding new Trusted Committers
 

--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -11,7 +11,7 @@ Trusted committers (TCs) are those members of our working group who have elevate
 
 ## Hall of Fame (aka Alumni)
 
-While Trusted Committers are in principal appointed for lifetime, it does happen that the interests or priorities of a TC change and they don't have enough time any more to contribute to the project. In those cases we ask them if we should move them to our Hall of Fame. Doing so allows us to appropriately thank them for all of their fantastic contributions. Of course they can always start contributing again in the future and go back to being Trusted Committers.
+While Trusted Committers are in principle appointed for lifetime, it does happen that the interests or priorities of a TC change and they don't have enough time any more to contribute to the project. In those cases we ask them if we should move them to our Hall of Fame. Doing so allows us to appropriately thank them for all of their fantastic contributions. Of course they can always start contributing again in the future and go back to being Trusted Committers.
 
 * [@gruetter](https://github.com/gruetter) (added 2017-03-02)
 * [@nyeates](https://github.com/nyeates) (added 2017-03-02)

--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -1,6 +1,12 @@
 # Trusted Committers
 
-Trusted committers (TCs) are those members of our working group who have elevated rights and direct write access to this repository. *TCs act as stewards of the working group and community. They aim to make consensus-based decisions in the best interest of the working group.* They also act as the guardians of this repository: TCs react to, referee, and give feedback about incoming contributions.
+Trusted Committers (TCs) are those members of our working group who have elevated rights and direct write access to this repository.
+
+> Trusted Committers act as stewards of the working group and community. They aim to make consensus-based decisions in the best interest of the working group. 
+
+They also act as the guardians of this repository: TCs react to, referee, and give feedback about incoming contributions.
+
+For further information about the concept, also see the [Trusted Committer Pattern](patterns/2-structured/trusted-committer.md).
 
 ## Current Trusted Committers
 
@@ -11,7 +17,11 @@ Trusted committers (TCs) are those members of our working group who have elevate
 
 ## Hall of Fame (aka Alumni)
 
-While Trusted Committers are in principle appointed for lifetime, it does happen that the interests or priorities of a TC change and they don't have enough time any more to contribute to the project. In those cases we ask them if we should move them to our Hall of Fame. Doing so allows us to appropriately thank them for all of their fantastic contributions. Of course they can always start contributing again in the future and go back to being Trusted Committers.
+While Trusted Committers are in principle appointed for lifetime, interests or priorities of a TC can change and they might not have enough time any more to contribute to the project. 
+
+In those cases we ask them if we should move them to the Hall of Fame. Doing so allows us to appropriately thank them for all of their fantastic contributions. When doing so we also remove them from `.github/CODEOWNERS`, so that reviews of Pull Requests aren't assigned to them anymore, and GitHub notifications are reduced. That increases the clarity for the community who to expect feedback from when creating PRs.
+
+The alumni in the Hall of Fame can of course always start contributing again in the future and go back to being Trusted Committers if they want to.
 
 * [@gruetter](https://github.com/gruetter) (added 2017-03-02)
 * [@nyeates](https://github.com/nyeates) (added 2017-03-02)
@@ -39,4 +49,6 @@ We follow this process (adapted from [here](https://tech.europace.de/voting-in-n
 
 ## Admins
 
-A handful of individuals are currently the technical GitHub Admins for this repository. This includes most members of the InnerSource Commons' #tech-infra team and members of the [InnerSource Commons GitHub Organization](https://github.com/innersourcecommons). However, please channel working group-specific requests through the trusted committers.
+A handful of individuals are currently the technical GitHub Admins for this repository. This includes most members of the InnerSource Commons' #tech-infra team and members of the [InnerSource Commons GitHub Organization](https://github.com/innersourcecommons). 
+
+However, please channel working group-specific requests through the trusted committers.


### PR DESCRIPTION
While a Trusted Committer (TC) is in principle appointed for lifetime, it does happen that the interests or priorities of a TC change and they don't have enough time any more to contribute to the project.

In those cases we ask them if we should move them to our Hall of Fame. Doing so allows us to appropriately thank them for all of their fantastic contributions. Of course they can always start contributing again in the future and go back to being Trusted Committers.

Maintaining a list of TCs with a minimum level of activity has some advantages:

* **for the community** - more clarity from whom they get expect feedback for their PRs, and who can answer questions about the project
* **for the inactive TCs** - by removing them from the `CODEOWNERS` file we reduce the GitHub notifications and emails that they receive from us that they likely don't need

Thank you @nyeates or @gruetter for all your fantastic contributions to the InnerSource Patterns over the years. Of course we know that you love the Patterns dearly, so hopefully you will still contribute new thoughts to this community as you discover new InnerSource Patterns in the wild :)

I will leave this open **until Feb 9th** to see if @nyeates or @gruetter object to this. If they do, and if they would rather remain in the TCs list, we are more than happy to keep them there. (I have already partly confirmed this in private Slack conversations but I wanted to put this into the open as well to make the process more transparent).