### PR TITLE
Add links to Europace blog posts

### DIFF
--- a/patterns/2-structured/project-setup/base-documentation.md
+++ b/patterns/2-structured/project-setup/base-documentation.md
@@ -105,7 +105,7 @@ started right away: [README-template.md](templates/README-template.md) and
 
 ## Known Instances
 
-* Europace AG
+* Europace AG - See blog post [InnerSource: Adding base documentation](https://tech.europace.de/post/innersource-base-documentation/)
 * Paypal Inc.
 
 ## Authors

--- a/patterns/2-structured/project-setup/issue-tracker.md
+++ b/patterns/2-structured/project-setup/issue-tracker.md
@@ -49,7 +49,7 @@ development but also during the planning phase of new features:
 
 ## Known Instances
 
-* Europace AG
+* Europace AG - See blog post [Issue Use Cases](https://tech.europace.de/post/using-issues-for-asking-questions-and-tracking-work/) 
 
 ## Authors
 

--- a/patterns/2-structured/project-setup/issue-tracker.md
+++ b/patterns/2-structured/project-setup/issue-tracker.md
@@ -49,7 +49,7 @@ development but also during the planning phase of new features:
 
 ## Known Instances
 
-* Europace AG - See blog post [Issue Use Cases](https://tech.europace.de/post/using-issues-for-asking-questions-and-tracking-work/) 
+* Europace AG - See blog post [Issue Use Cases](https://tech.europace.de/post/using-issues-for-asking-questions-and-tracking-work/)
 
 ## Authors
 


### PR DESCRIPTION
I found some articles on the[ Europace blog](https://tech.europace.de/post/running-an-innersource-initiative-leading-by-example/) that we can link to some of our patterns. Not that surprizing as those patterns were written by @MaineC :)