### PR TITLE
Fix contracted contributor book display

### DIFF
--- a/patterns/2-structured/contracted-contributor.md
+++ b/patterns/2-structured/contracted-contributor.md
@@ -18,7 +18,7 @@ This runs the risk of top level management abandoning the InnerSource idea.
 ## Context
 
 A large corporation has started an InnerSource initiative. Major goals for the
-initiative are to increase the efficiency of distributed software develoment
+initiative are to increase the efficiency of distributed software development
 and to foster innovation by allowing every associate to voluntarily
 contribute to InnerSource projects, regardless of topic and business unit.
 
@@ -29,8 +29,7 @@ capacity for community leaders and are largely giving autonomy as for how the
 budget is spent. They are also limiting the breadth and duration of the
 initiative and partake in periodic reviews until there is proof that it yields
 the expected results (see [Review Committee](review-committee.md)).  Top level
-management has announced their support for InnerSource on various company
-internal meetings.
+management has announced their support for InnerSource on various company-internal meetings.
 
 However, top level management has not yet empowered or incentivised mid-level
 managers to allow or even motivate their employees to participate in
@@ -49,7 +48,7 @@ hours, not during free time.
 - The less transparency and control a line manager has of work done by one of her subordinates, the less likely is she to allow her to contribute.
 - The less formally work in InnerSource is managed and organised, the less likely a line manager who is accustomed to formal processes is to sign off on one of her employees contributing to InnerSource.
 - The more time an associate spends on contributions to an InnerSource project which does not benefit his day-to-day work, the more will the workload for his teammates in his business unit increase.
-- Individual contributors will likely consider participating in InnerSource as an opportunity to enhance their professional network within the company and to gain knowledege and experience in the technical area of her contributions.
+- Individual contributors will likely consider participating in InnerSource as an opportunity to enhance their professional network within the company and to gain knowledge and experience in the technical area of her contributions.
 
 ## Solution
 
@@ -59,7 +58,7 @@ ISGO reimburse business units who contracted contributors for the contracted
 time.
 
 - The contracting specifies a maximum percentage of the associates work time in InnerSource.
-- The contracting clearly states that work in the contributor's business unit takes precendence over work in InnerSource.
+- The contracting clearly states that work in the contributor's business unit takes precedence over work in InnerSource.
 - The contracting states that it is not required to work in InnerSource for the maximum percentage specified in the contract.
 - The contracting is signed by the contributor, the contributor's line manager, the governance office and the [Dedicated Community Leader](dedicated-community-leader.md) of the community the contributor will be contributing to.
 - The governance office offers to mediate between the contributor and her line manager in case of conflict regarding the time for contributions.
@@ -80,7 +79,7 @@ empowering middle management to sign off on it:
 A formal contracting is also beneficial for contributors and communities:
 
 - With a stable group of contributors, it is more likely that some of them will eventually achieve [Trusted Committer](./trusted-committer.md) status.
-- A formal contracting provides a basis for resolving conflict related to participation in InnerSource activities. Note that mediation will likely be successful only for a few companies with a culture condusive to that.
+- A formal contracting provides a basis for resolving conflict related to participation in InnerSource activities. Note that mediation will likely be successful only for a few companies with a culture conducive to that.
 
 ## Known Instances
 

--- a/patterns/2-structured/contracted-contributor.md
+++ b/patterns/2-structured/contracted-contributor.md
@@ -43,29 +43,13 @@ hours, not during free time.
 
 ## Forces
 
-- Managers are held responsible for the results of their business units.
-  Letting their staff participate in InnerSource activities which might spend
-  time making contributions outside of their business unit effectively reduces
-  the capacity of his or her unit. This will likely make it harder for the
-  managers to reach or exceed their goals.
-- Line managers and HR will, by default, judge the performance of their
-  subordinates against their business units goals, which might not be aligned
-  with the goals of the InnerSource community.
-- The less executive air cover a line manager perceives he has, the less likely
-  is he or she to have his or her staff participate in InnerSource activities
-  which contribute to another business unit.
-- The less transparency and control a line manager has of work done by one of
-  her subordinates, the less likely is she to allow her to contribute.
-- The less formally work in InnerSource is managed and organised, the less
-  likely a line manager who is accustomed to formal processes is to sign off on
-  one of her employees contributing to InnerSource.
-- The more time an associate spends on contributions to an InnerSource project
-  which does not benefit his day-to-day work, the more will the workload for
-  his teammates in his business unit increase.
-- Individual contributors will likely consider participating in InnerSource
-  as an opportunity to enhance their professional network within the company
-  and to gain knowledege and experience in the technical area of her
-  contributions.
+- Managers are held responsible for the results of their business units. Letting their staff participate in InnerSource activities which might spend time making contributions outside of their business unit effectively reduces the capacity of his or her unit. This will likely make it harder for the managers to reach or exceed their goals.
+- Line managers and HR will, by default, judge the performance of their subordinates against their business units goals, which might not be aligned with the goals of the InnerSource community.
+- The less executive air cover a line manager perceives he has, the less likely is he or she to have his or her staff participate in InnerSource activities which contribute to another business unit.
+- The less transparency and control a line manager has of work done by one of her subordinates, the less likely is she to allow her to contribute.
+- The less formally work in InnerSource is managed and organised, the less likely a line manager who is accustomed to formal processes is to sign off on one of her employees contributing to InnerSource.
+- The more time an associate spends on contributions to an InnerSource project which does not benefit his day-to-day work, the more will the workload for his teammates in his business unit increase.
+- Individual contributors will likely consider participating in InnerSource as an opportunity to enhance their professional network within the company and to gain knowledege and experience in the technical area of her contributions.
 
 ## Solution
 
@@ -74,21 +58,12 @@ centrally funded and steered InnerSource governance office (ISGO). Have the
 ISGO reimburse business units who contracted contributors for the contracted
 time.
 
-- The contracting specifies a maximum percentage of the associates work time in
-  InnerSource.
-- The contracting clearly states that work in the contributor's business unit
-  takes precendence over work in InnerSource.
-- The contracting states that it is not required to work in InnerSource for the
-  maximum percentage specified in the contract.
-- The contracting is signed by the contributor, the contributor's line manager,
-  the governance office and the [Dedicated Community
-  Leader](dedicated-community-leader.md) of the community the contributor will
-  be contributing to.
-- The governance office offers to mediate between the contributor and her line
-  manager in case of conflict regarding the time for contributions.
-- The [Dedicated Community Leader](dedicated-community-leader.md) participates
-  in or provides input for performance reviews of contributors contracted for
-  more than 20 %.
+- The contracting specifies a maximum percentage of the associates work time in InnerSource.
+- The contracting clearly states that work in the contributor's business unit takes precendence over work in InnerSource.
+- The contracting states that it is not required to work in InnerSource for the maximum percentage specified in the contract.
+- The contracting is signed by the contributor, the contributor's line manager, the governance office and the [Dedicated Community Leader](dedicated-community-leader.md) of the community the contributor will be contributing to.
+- The governance office offers to mediate between the contributor and her line manager in case of conflict regarding the time for contributions.
+- The [Dedicated Community Leader](dedicated-community-leader.md) participates in or provides input for performance reviews of contributors contracted for more than 20 %.
 
 <img alt="Contracted Contributor" src="/assets/img/contracted-contributor.png" width="70%">
 
@@ -98,28 +73,18 @@ A formal contracting and centrally funded reimbursements convincingly
 communicating the organizations support for the InnerSource initiative, thus
 empowering middle management to sign off on it:
 
-- Allocation of corporate funds to business units for reimbursement of
-  development capacity signals to line managers that InnerSource is deemed
-  valuable by the organization, that it has executive air cover and that they
-  are expected to support it, too.
-- A formal contracting signals that work in InnerSource is managed
-  professionally and inspires trust.
-- A formal contracting increases transparency and provides a better overview
-  about the associate's available capacity for his business unit and
-  InnerSource projects, thus reducing the risk of "over-booked/planned
-  capacity".
+- Allocation of corporate funds to business units for reimbursement of development capacity signals to line managers that InnerSource is deemed valuable by the organization, that it has executive air cover and that they are expected to support it, too.
+- A formal contracting signals that work in InnerSource is managed professionally and inspires trust.
+- A formal contracting increases transparency and provides a better overview about the associate's available capacity for his business unit and InnerSource projects, thus reducing the risk of "over-booked/planned capacity".
 
 A formal contracting is also beneficial for contributors and communities:
 
-- With a stable group of contributors, it is more likely that some of them will
-  eventually achieve [Trusted Committer](./trusted-committer.md) status.
-- A formal contracting provides a basis for resolving conflict related to
-  participation in InnerSource activities. Note that mediation will likely be
-  successful only for a few companies with a culture condusive to that.
+- With a stable group of contributors, it is more likely that some of them will eventually achieve [Trusted Committer](./trusted-committer.md) status.
+- A formal contracting provides a basis for resolving conflict related to participation in InnerSource activities. Note that mediation will likely be successful only for a few companies with a culture condusive to that.
 
 ## Known Instances
 
-- _BIOS at Robert Bosch GmbH_.
+- BIOS at Robert Bosch GmbH
 
 ## Status
 
@@ -147,3 +112,4 @@ A formal contracting is also beneficial for contributors and communities:
 - **2016-10-25** - first review
 - **2017-05-09** - rework
 - **2017-09-08** - second review, final rework and merged
+- **2021-02-27** - fixing issues with display of the pattern in the book


### PR DESCRIPTION
Changes:

* Removing extra linebreaks, to make lists get displayed correctly in the book.
* While at it, also fixed some typos