### PR TITLE
Rename dedicated community manager

### DIFF
--- a/patterns/1-initial/incentive-mechanisms-for-voluntary-contribution.md
+++ b/patterns/1-initial/incentive-mechanisms-for-voluntary-contribution.md
@@ -30,7 +30,7 @@ InnerSource project.
 
 As a result, the total number of contributors remained restricted to the core team and the
 project cannot build a community of developers. Furthermore, contributions mostly originated
-in the same business unit the [Dedicated Community Leader](../2-structured/dedicated-community-leader.md) 
+in the same business unit the [Dedicated Community Leader](../2-structured/dedicated-community-leader.md)
 belonged to. Innovation did not happen in the expected scale. Top management is no longer
 convinced that InnerSource yields the expected benefits and abandons the initiative altogether.
 

--- a/patterns/1-initial/incentive-mechanisms-for-voluntary-contribution.md
+++ b/patterns/1-initial/incentive-mechanisms-for-voluntary-contribution.md
@@ -30,7 +30,7 @@ InnerSource project.
 
 As a result, the total number of contributors remained restricted to the core team and the
 project cannot build a community of developers. Furthermore, contributions mostly originated
-in the same business unit the Dedicated Community Leader (link to Dedicated Community Leader)
+in the same business unit the [Dedicated Community Leader](dedicated-community-leader.md) 
 belonged to. Innovation did not happen in the expected scale. Top management is no longer
 convinced that InnerSource yields the expected benefits and abandons the initiative altogether.
 

--- a/patterns/1-initial/incentive-mechanisms-for-voluntary-contribution.md
+++ b/patterns/1-initial/incentive-mechanisms-for-voluntary-contribution.md
@@ -30,7 +30,7 @@ InnerSource project.
 
 As a result, the total number of contributors remained restricted to the core team and the
 project cannot build a community of developers. Furthermore, contributions mostly originated
-in the same business unit the [Dedicated Community Leader](dedicated-community-leader.md) 
+in the same business unit the [Dedicated Community Leader](../2-structured/dedicated-community-leader.md) 
 belonged to. Innovation did not happen in the expected scale. Top management is no longer
 convinced that InnerSource yields the expected benefits and abandons the initiative altogether.
 

--- a/patterns/2-structured/dedicated-community-leader.md
+++ b/patterns/2-structured/dedicated-community-leader.md
@@ -26,7 +26,7 @@ Consider the following story. A company wants to start an InnerSource initiative
 
 ## Forces
 
-If a company does not significantly invest in the initial InnerSource community in terms of budget and capacity for InnerSource, the credibility of its commitment to InnerSource might be perceived as questionable. A common impulse of a company with a traditional management culture to a project or initiative not performing as expected will be to replace its leader. Doing that without involving the community and following meritocratic principles will further undermine the companies commitment to InnerSource by highlighting the friction between the current company culture and the target culture - a community culture.
+If a company does not significantly invest in the initial InnerSource community in terms of budget and capacity for InnerSource, the credibility of its commitment to InnerSource might be perceived as questionable. A common impulse of a company with a traditional management culture to a project or initiative not performing as expected will be to replace its leader. Doing that without involving the community and following meritocratic principles will further undermine the company's commitment to InnerSource by highlighting the friction between the current company culture and the target culture - a community culture.
 
 The value contribution of InnerSource projects will not be obvious for many managers which are steeped in traditional project management methods. Those managers are less likely to assign one of their top people, who are usually in high demand by non InnerSource-projects, to an InnerSource project for a significant percentage of their work time.
 
@@ -52,7 +52,7 @@ Empower the community leader to dedicate 100 % of his time to community work inc
 
 ## Resulting Context
 
-A community leader with the properties described above will lend a face and embody the companies commitment to InnerSource. It will make it more likely that other associates in his network will follow his lead and contribute to InnerSource. Over time, he or she will be able to build up a stable core team of developers and hence increase the chances of success for the InnerSource project. By convincingly a large enough audience within his company of the potential of InnerSource, he or she will make an important contribution to changing the company culture towards a community culture.
+A community leader with the properties described above will lend a face and embody the company's commitment to InnerSource. It will make it more likely that other associates in his network will follow his lead and contribute to InnerSource. Over time, he or she will be able to build up a stable core team of developers and hence increase the chances of success for the InnerSource project. By convincingly a large enough audience within his company of the potential of InnerSource, he or she will make an important contribution to changing the company culture towards a community culture.
 
 Having excellent and dedicated community leaders is a precondition for the success of InnerSource. It is, however, not a silver bullet. There are many challenges of InnerSource which are above and beyond what a community leader can tackle, such as budgetary, legal, fiscal or other organizational challenges.
 

--- a/patterns/2-structured/dedicated-community-leader.md
+++ b/patterns/2-structured/dedicated-community-leader.md
@@ -1,6 +1,6 @@
 ## Title
 
-Dedicated Community Manager
+Dedicated Community Leader
 
 ## Patlet
 
@@ -8,7 +8,7 @@ Select people with both communications and technical skills to lead the communit
 
 ## Problem
 
-How do you ensure that a new InnerSource initiative has the right [community manager](http://www.artofcommunityonline.org/) to grow it's impact?
+How do you ensure that a new InnerSource initiative has the right [community leader](http://www.artofcommunityonline.org/) to grow it's impact?
 
 Selecting the wrong persons and/or not providing enough capacity for them risks wasted effort and ultimately the failure of a new InnerSource initiative.
 
@@ -30,7 +30,7 @@ If a company does not significantly invest in the initial InnerSource community 
 
 The value contribution of InnerSource projects will not be obvious for many managers which are steeped in traditional project management methods. Those managers are less likely to assign one of their top people, who are usually in high demand by non InnerSource-projects, to an InnerSource project for a significant percentage of their work time.
 
-Communication takes up a significant percentage of a community managers daily work. At the same time, he or she will likely also have to spearhead the initial development, too. In the face of limited capacity, inexperienced leaders will tend to focus on development and neglect communication. The barrier for potential contributors to make their first contribution and to commit to the community will be much higher if the community leader is hard to reach or is slow to respond to feedback and questions for lack of time. Furthermore, technically inexperienced leaders will most likely have a harder time to attract and retain highly experienced contributors than a top performer with a high degree of visibility within a company would have.
+Communication takes up a significant percentage of a community leader's daily work. At the same time, he or she will likely also have to spearhead the initial development, too. In the face of limited capacity, inexperienced leaders will tend to focus on development and neglect communication. The barrier for potential contributors to make their first contribution and to commit to the community will be much higher if the community leader is hard to reach or is slow to respond to feedback and questions for lack of time. Furthermore, technically inexperienced leaders will most likely have a harder time to attract and retain highly experienced contributors than a top performer with a high degree of visibility within a company would have.
 
 If a community can not grow fast enough and pick up enough speed, chances are they won't be able to convincingly demonstrate the potential of InnerSource.
 
@@ -62,7 +62,7 @@ _BIOS at Robert Bosch GmbH_. Note that InnerSource at Bosch was, for the majorit
 
 ## Alias
 
-Dedicated Community Leader
+Dedicated Community Manager
 
 ## Status
 


### PR DESCRIPTION
The pattern in question is currently called [Dedicated Community Manager](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/dedicated-community-leader.md), however that may have been a mistake when choosing between the available options for the pattern title (see bdefaafd10bb2a2c883d4da3dca4268fb7dd725b).

The more appropriate name for the pattern might be **Dedicated Community Leader**, for various reasons:
* other patterns are already referring to it as Leader e.g. [Contracted Contributor](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/contracted-contributor.md)
* the file name is already `dedicated-community-leader.md`, so in the past there was likely a debate about the title `Leader` and `Manager` already 