### PR TITLE
Add a pattern for making shared ownership explicit.

### DIFF
--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -8,7 +8,11 @@ A software component that several teams depend on has grown to the point where o
 
 # Problem
 
-An organisation is already using InnerSource best practices in several teams. The architecture of the software offered has grown organically. Talking about code ownership and accountability teams notice that there is a component that is in a worrying state: Developed by an original team of authors it has grown it's userbase way beyond what the original team can handle. From time to time others step up to help out, however there is no formal process established. As a result conflicts arise around who should do the work, who should decide on project direction. Simply forking the component would lead to a lot of duplication and wasted effort. As a result teams are looking for a less intrusive solution to the issue.
+An organisation is already using InnerSource best practices in several teams. The architecture of the software offered has grown organically. 
+
+While talking about code ownership and accountability, teams notice that there is a component that is in a worrying state: Developed by an original team of authors it has grown it's userbase way beyond what the original team can handle. From time to time others step up to help out, however there is no formal process established. As a result, conflicts arise around who should do the work, and who should decide on project direction. 
+
+Simply forking the component would lead to a lot of duplication and wasted effort. Therefore the involved teams are looking for a less intrusive solution to the issue.
 
 # Context
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -29,7 +29,7 @@ Simply forking the component would lead to a lot of duplication and wasted effor
 - There are too many teams dependent on the component to pull everyone into one single meeting to discuss ownership.
 
 - There may be people dependent on the module that are not yet known.
-There often is fear around maintenance efforts arising from unwanted attribution to the project
+There often is fear around maintenance efforts arising from unwanted attribution to the project.
 
 # Solution
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -4,7 +4,7 @@ Explicit Shared Ownership
 
 # Patlet
 
-In a software system there is a component that several teams depend on. Initially developed by a handful of people it has long outgrown it's orignal use-case. Original authors are no longer capable of taking full ownership of that component. Development happens organically. Often there is confusion as to who should make changes, who needs to approve changes. Making ownership explicit, sharing that ownership across dependent teams, making expected behaviour explicit helps remove ambiguity. Writing those learnings down means that it can be changed according to the same process that is used to change the software.
+A software component that several teams depend on has grown to the point where owners are no longer capable of taking full ownership. There is confusion who to involve for changes. Sharing ownership explicitly and making expected behaviour visible removes ambiguity. Writing a contributions document creates a natural way to evolve ownership.
 
 # Problem
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -35,7 +35,7 @@ There often is fear around maintenance efforts arising from unwanted attribution
 
 Use the issue/ pull-request mechanics that work so well for code modifications to modify the way the component is developed:
 
-A volunteer creates an issue in the component's repository highlighting the apparent unclarity or even lack of ownership. Subsequently a volunteer (can be the same person) creates a suggestion for how the project should be developed going forward including a list of initial [Trusted Committers](../2-structured/trusted-committer.md). This suggestion is posted to the project's documentation (e.g. it's `README.md` file) as a pull request. This pull request is left open and shared with all people affected by the change. Feedback can be given and integrated asynchronously. Development of the final state is transparent for everyone.
+A volunteer creates an issue in the component's repository highlighting the apparent unclarity or even lack of ownership. Subsequently a volunteer (can be the same person) creates a suggestion for how the project should be developed going forward including a proposed list of initial [Trusted Committers](../2-structured/trusted-committer.md). This suggestion is posted to the project's documentation (e.g. it's `README.md` file) as a pull request. This pull request is left open and shared with all people affected by the change. Feedback can be given and integrated asynchronously. Development of the final state is transparent for everyone.
 
 # Resulting Context
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -10,7 +10,7 @@ A software component that several teams depend on has grown to the point where o
 
 An organisation is already using InnerSource best practices in several teams. The architecture of the software offered has grown organically.
 
-While talking about code ownership and accountability, teams notice that there is a component that is in a worrying state: Developed by an original team of authors it has grown it's userbase way beyond what the original team can handle. From time to time others step up to help out, however there is no formal process established. As a result, conflicts arise around who should do the work, and who should decide on project direction. 
+While talking about code ownership and accountability, teams notice that there is a component that is in a worrying state: Developed by an original team of authors it has grown it's userbase way beyond what the original team can handle. From time to time others step up to help out, however there is no formal process established. As a result, conflicts arise around who should do the work, and who should decide on project direction.
 
 Simply forking the component would lead to a lot of duplication and wasted effort. Therefore the involved teams are looking for a less intrusive solution to the issue.
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -12,11 +12,11 @@ An organisation is already using InnerSource best practices in several teams. Th
 
 # Context
 
-Teams are working independently but are providing one common platform as a service.
+- Teams are working independently but are providing one common platform as a service.
 
-The software they are working on has been evolving for a long time. Engineers working on sub-modules have changed over time.
+- The software they are working on has been evolving for a long time. Engineers working on sub-modules have changed over time.
 
-One component is in widespread use but ownership is unclear.
+- One component is in widespread use but ownership is unclear.
 
 # Forces
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -29,6 +29,7 @@ Ownership of one component is unclear.
 There are too many teams dependent on the component to pull everyone into one single meeting to discuss ownership.
 
 There may be people dependent on the module that are not yet known.
+There often is fear around maintenance efforts arising from unwanted attribution to the project
 
 # Solution
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -1,0 +1,51 @@
+# Title
+
+Explicit shared ownership
+
+# Patlet
+
+In a software system there is a component that several teams depend on. Initially developed by a handful of people it has long outgrown it's orignal use-case. Original authors are no longer capable of taking full ownership of that component. Development happens organically. Often there is confusion as to who should make changes, who needs to approve changes. Making ownership explicit, sharing that ownership across dependent teams, making expected behaviour explicit helps remove ambiguity. Writing those learnings down means that it can be changed according to the same process that is used to change the software.
+
+# Problem
+
+An organisation is already using InnerSource best practices in several teams. The architecture of the software offered has grown organically. Talking about code ownership and accountability teams notice that there is a component that is in a worrying state: Developed by an original team of authors it has grown it's userbase way beyond what the original team can handle. From time to time others step up to help out, however there is no formal process established. As a result conflicts arise around who should do the work, who should decide on project direction. Simply forking the component would lead to a lot of duplication and wasted effort. As a result teams are looking for a less intrusive solution to the issue.
+
+# Context
+
+Teams are working in independently but providing one common platform as a service.
+
+The software they are working on has been evolving for a long time. Engineers working on sub-modules have changed over time.
+
+One component is in widespread use but ownership is unclear.
+
+
+# Forces
+
+Ownership of one component is unclear.
+
+There are too many teams dependent on the component to pull everyone into one single meeting to discuss ownership.
+
+There may be people dependent on the module that are not yet known.
+
+
+# Solution
+
+Use the issue/ pull-request mechanics that work so well for code modifications to modify the way the component is developed:
+
+A volunteer creates an issue in the component's repository highlighting the apparent unclarity or even lack of ownership. Subsequently a volunteer (can be the same person) creates a suggestion for how the project should be developed going forward including a list of initial Trusted Committers. This suggestion is posted to the project's documentation (e.g. it's README.md file) as a pull request. This pull request is left open and shared with all people affected by the change. Feedback can be given and integrated asynchronously. Development of the final state is transparent for everyone.
+
+# Resulting Context
+
+There is an initial team of Trusted Committers committed to the component.
+
+Expectations related to collaboration are transparent for everyone involved going forward.
+
+The entire decision process backing the result is transparent and can be influenced by those affected leading to higher buy-in for the final result. Also the argument leading to the final decisions are accessible for those new to the project.
+
+There is a proven way to adjust the setup in the future.
+
+
+# Status
+
+Initial (early draft)
+

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -38,7 +38,7 @@ There is an initial team of Trusted Committers committed to the component.
 
 Expectations related to collaboration are transparent for everyone involved going forward.
 
-The entire decision process backing the result is transparent and can be influenced by those affected leading to higher buy-in for the final result. Also the argument leading to the final decisions are accessible for those new to the project.
+The entire decision process backing the result is transparent and can be influenced by those affected, leading to higher buy-in for the final result. Also the argument leading to the final decisions are accessible for those new to the project.
 
 There is a proven way to adjust the setup in the future.
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -1,6 +1,6 @@
 # Title
 
-Explicit shared ownership
+Explicit Shared Ownership
 
 # Patlet
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -18,7 +18,6 @@ The software they are working on has been evolving for a long time. Engineers wo
 
 One component is in widespread use but ownership is unclear.
 
-
 # Forces
 
 Ownership of one component is unclear.
@@ -26,7 +25,6 @@ Ownership of one component is unclear.
 There are too many teams dependent on the component to pull everyone into one single meeting to discuss ownership.
 
 There may be people dependent on the module that are not yet known.
-
 
 # Solution
 
@@ -44,8 +42,6 @@ The entire decision process backing the result is transparent and can be influen
 
 There is a proven way to adjust the setup in the future.
 
-
 # Status
 
 Initial (early draft)
-

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -24,11 +24,11 @@ Simply forking the component would lead to a lot of duplication and wasted effor
 
 # Forces
 
-Ownership of one component is unclear.
+- Ownership of one component is unclear.
 
-There are too many teams dependent on the component to pull everyone into one single meeting to discuss ownership.
+- There are too many teams dependent on the component to pull everyone into one single meeting to discuss ownership.
 
-There may be people dependent on the module that are not yet known.
+- There may be people dependent on the module that are not yet known.
 There often is fear around maintenance efforts arising from unwanted attribution to the project
 
 # Solution

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -39,7 +39,7 @@ A volunteer creates an issue in the component's repository highlighting the appa
 
 # Resulting Context
 
-There is an initial team of Trusted Committers committed to the component.
+There is an initial team of [Trusted Committers](../2-structured/trusted-committer.md) committed to the component.
 
 Expectations related to collaboration are transparent for everyone involved going forward e.g. by creating [base documentation in CONTRIBUTING.md](../2-structured/project-setup/base-documentation.md).
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -8,7 +8,7 @@ A software component that several teams depend on has grown to the point where o
 
 # Problem
 
-An organisation is already using InnerSource best practices in several teams. The architecture of the software offered has grown organically. 
+An organisation is already using InnerSource best practices in several teams. The architecture of the software offered has grown organically.
 
 While talking about code ownership and accountability, teams notice that there is a component that is in a worrying state: Developed by an original team of authors it has grown it's userbase way beyond what the original team can handle. From time to time others step up to help out, however there is no formal process established. As a result, conflicts arise around who should do the work, and who should decide on project direction. 
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -41,7 +41,7 @@ A volunteer creates an issue in the component's repository highlighting the appa
 
 There is an initial team of Trusted Committers committed to the component.
 
-Expectations related to collaboration are transparent for everyone involved going forward.
+Expectations related to collaboration are transparent for everyone involved going forward e.g. by creating [base documentation in CONTRIBUTING.md](../2-structured/project-setup/base-documentation.md).
 
 The entire decision process backing the result is transparent and can be influenced by those affected, leading to higher buy-in for the final result. Also the argument leading to the final decisions are accessible for those new to the project.
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -12,7 +12,7 @@ An organisation is already using InnerSource best practices in several teams. Th
 
 # Context
 
-Teams are working in independently but providing one common platform as a service.
+Teams are working independently but are providing one common platform as a service.
 
 The software they are working on has been evolving for a long time. Engineers working on sub-modules have changed over time.
 

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -30,7 +30,7 @@ There may be people dependent on the module that are not yet known.
 
 Use the issue/ pull-request mechanics that work so well for code modifications to modify the way the component is developed:
 
-A volunteer creates an issue in the component's repository highlighting the apparent unclarity or even lack of ownership. Subsequently a volunteer (can be the same person) creates a suggestion for how the project should be developed going forward including a list of initial Trusted Committers. This suggestion is posted to the project's documentation (e.g. it's README.md file) as a pull request. This pull request is left open and shared with all people affected by the change. Feedback can be given and integrated asynchronously. Development of the final state is transparent for everyone.
+A volunteer creates an issue in the component's repository highlighting the apparent unclarity or even lack of ownership. Subsequently a volunteer (can be the same person) creates a suggestion for how the project should be developed going forward including a list of initial [Trusted Committers](../2-structured/trusted-committer.md). This suggestion is posted to the project's documentation (e.g. it's `README.md` file) as a pull request. This pull request is left open and shared with all people affected by the change. Feedback can be given and integrated asynchronously. Development of the final state is transparent for everyone.
 
 # Resulting Context
 


### PR DESCRIPTION
In cases where projects are already owned by multiple teams but without clear explicit Trusted Committers this pattern can help to bootstrap an initial set of TCs.