### PR TITLE
Make the switch from master to main branch

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -3,7 +3,7 @@ name: Book ToC Generation
 on:
   push:
     branches:
-      - "master"
+      - "main"
       - "book-staging"
 
 jobs:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -6,7 +6,7 @@ name: Link Check on Patterns and README
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
 
 jobs:

--- a/.github/workflows/lint-patterns.yml
+++ b/.github/workflows/lint-patterns.yml
@@ -4,7 +4,7 @@ name: Pattern Syntax Validation
 on:
   push:
     branches:
-      - "master"
+      - "main"
   pull_request:
     paths:
       - ".github/workflows/lint-patterns.yml"


### PR DESCRIPTION
This implements #224 .

## TODO

- [x] rename `master` to `main` via the GitHub project settings
- [x] update GitHub Actions to trigger on `main`
- [x] change gitbook integration to build from `main`
- [x] inform all people with forks and clones that they have to make the switch too