### PR TITLE
Add InnerSource principles to list of draft patterns

### DIFF
--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -138,7 +138,6 @@ The organisation development practices move closer to open source projects thus
 making it easier for organisation members to participate in open source
 projects.
 
-
 ## Known Instances
 
 Europace AG
@@ -146,4 +145,3 @@ Europace AG
 ## Status
 
 draft
-

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -1,6 +1,6 @@
 ## Title
 
-_Explicit InnerSource principles_
+Explicit InnerSource Principles
 
 ## Patlet
 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -4,10 +4,10 @@ Explicit InnerSource Principles
 
 ## Patlet
 
-InnerSource as a term is circulating among employees. The usual explanation of
-"applying open source best practices inside an organisation" does not work well
-though with people lacking an open source background. As a remedy the most
-important principles of InnerSource get published widely.
+The usual InnerSource explanation of "applying open source best practices 
+inside an organisation" does not work well with people lacking an 
+open source background. As a remedy the most important principles of 
+InnerSource get published widely.
 
 ## Problem
 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -38,7 +38,6 @@ open source best practices into the organisation.
 On a daily basis teams trying to follow InnerSource best practices have a hard
 time deciding if what they are doing is inline with general InnerSource values.
 
-
 ## Solution
 
 Those involved with the InnerSource initiative in the organisation need to
@@ -148,6 +147,5 @@ Europace AG
 ## Status
 
 draft
-
 
 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -5,16 +5,16 @@ Explicit InnerSource Principles
 ## Patlet
 
 InnerSource as a term is circulating among employees. The usual explanation of
-"applying Open Source best practices inside an organisation" does not work well
-though with people lacking an Open Source background. As a remedy the most
+"applying open source best practices inside an organisation" does not work well
+though with people lacking an open source background. As a remedy the most
 important principles of InnerSource get published widely.
 
 ## Problem
 
 The organisation is trying to roll out InnerSource at a larger scale. The
-initiative started among Open Source enthusiasts. The goal is now to get buy-in
-from people that are lacking Open Source experience. For that audience the typical
-slogan of "applying Open Source best practices" is not longer sufficient to
+initiative started among open source enthusiasts. The goal is now to get buy-in
+from people that are lacking open source experience. For that audience the typical
+slogan of "applying open source best practices" is not longer sufficient to
 transport the message of what InnerSource is, which problems it solves and which
 tools it uses for solving these issues.
 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -30,6 +30,11 @@ teams and individuals lacking a deep background in open source.
 The goal now is to clearly communicate the goals of the InnerSource initiative
 as well as a clear path towards achieving these goals.
 
+## Context
+
+* InnerSource as a term is circulating among employees.
+* The initiative started among open source enthusiasts. 
+
 ## Forces
 
 * Teams have trouble communicating exactly what the important aspects of

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -14,11 +14,14 @@ important principles of InnerSource get published widely.
 The organisation is trying to roll out InnerSource at a larger scale. The
 initiative started among open source enthusiasts. The goal is now to get buy-in
 from people that are lacking open source experience. For that audience the typical
-slogan of "applying open source best practices" is not longer sufficient to
+slogan of "applying open source best practices" is no longer sufficient to
 transport the message of what InnerSource is, which problems it solves and which
-tools it uses for solving these issues.
+tools it uses for solving these issues. As a result InnerSource adoption in the 
+organisation slows down. Teams develop diverging ideas of what the goals of InnerSource
+is about and how to best implement it leading to confusion when contributors
+are starting to cross team boundaries. 
 
-## Context
+## Story
 
 Early experiments in an organisation have shown that open source collaboration
 best practices can be beneficial. The goal now is to move the initiative to
@@ -40,8 +43,7 @@ time deciding if what they are doing is inline with general InnerSource values.
 
 ## Solution
 
-Those involved with the InnerSource initiative in the organisation need to
-understand two perspectives:
+Those that should adopt InnerSource need to understand two perspectives:
 
 ### Why does the organisation want to adopt InnerSource?
 
@@ -91,14 +93,7 @@ everyone. As a result a culture must be established in which mistakes are
 opportunities for learning instead of failure that should be avoided at all
 cost.
 
-4. Allow written advise to accrete in a persistent, searchable archive
-
-All project communication, in particular decisions taken and discussions leading
-up to those decisions need to be archived. It must be possible to reference
-communication via stable URLs. Previous communication needs to be stored in a
-way that can easily be searched.
-
-5. Written over verbal communication
+4. Written over verbal communication
 
 For projects that span multiple teams, potentially on diverging meeting
 schedules, it needs to be possible to collaborate asynchronously. The goal for
@@ -109,6 +104,13 @@ happens through synchronous communication, arguments discussed need to be made
 transparent in the written channel - decisions should be finalized only there.
 As a side effect this leads to passive base documentation that is very valuable
 for any newcomer to the project.
+
+5. Allow written advise to accumulate in a persistent, searchable archive
+
+All project communication, in particular decisions taken and discussions leading
+up to those decisions need to be archived. It must be possible to reference
+communication via stable URLs. Previous communication needs to be stored in a
+way that can easily be searched.
 
 Two caveats though:
 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -11,16 +11,16 @@ important principles of InnerSource get published widely.
 
 ## Problem
 
-The organisation is trying to role out InnerSource at a larger scale. The
-initiative started among Open Source enthusiasts. The goal is now to get buy in
-from people that are lacking Open Source experience. As a result the typical
+The organisation is trying to roll out InnerSource at a larger scale. The
+initiative started among Open Source enthusiasts. The goal is now to get buy-in
+from people that are lacking Open Source experience. For that audience the typical
 slogan of "applying Open Source best practices" is not longer sufficient to
 transport the message of what InnerSource is, which problems it solves and which
 tools it uses for solving these issues.
 
 ## Context
 
-In an organisation early experiments have shown that open source collaboration
+Early experiments in an organisation have shown that open source collaboration
 best practices can be beneficial. The goal now is to move the initiative to
 teams and individuals lacking a deep background in open source.
 
@@ -29,13 +29,13 @@ as well as a clear path towards achieving these goals.
 
 ## Forces
 
-Teams have trouble communicating exactly what the important aspects of
+* Teams have trouble communicating exactly what the important aspects of
 InnerSource are.
 
-People lacking open source experience fail to understand what it means to bring
+* People lacking open source experience fail to understand what it means to bring
 open source best practices into the organisation.
 
-On a daily basis teams trying to follow InnerSource best practices have a hard
+* On a daily basis teams trying to follow InnerSource best practices have a hard
 time deciding if what they are doing is inline with general InnerSource values.
 
 ## Solution
@@ -48,8 +48,10 @@ understand two perspectives:
 In the past InnerSource has proven to be successful to solve several issues
 commonly found in organisations. Instead of going for generalizations, try to
 exactly identify the solutions that match the challenges of your organisation -
-preferably with those affected by the change you want to see. Some challenges
-that others have addressed by following InnerSource best practices:
+preferably with those affected by the change you want to see. 
+
+Some challenges that others have addressed by following InnerSource 
+best practices:
 
 * Reduce development silos caused by excessive ownership culture.
 * Increase innovation speed by reducing time spent solving similar issues by
@@ -64,17 +66,18 @@ that others have addressed by following InnerSource best practices:
 
 ### Provide clear InnerSource principles
 
-Once teams understand which problems InnerSource will help them address the next
-step is to explain which basic values help address these challenges. Based on
-basic open source development principles the following guidelines have been
-proven successful:
+Once teams understand which problems InnerSource will help them address, the next
+step is to explain which principles help address these challenges. 
 
-1. Code must be transparently hosted within the organisation.
+Based on basic open source development principles the following guidelines 
+have been proven successful:
+
+1. Code must be transparently hosted within the organisation
 
 Source code, documentation, data relevant for project development must be
 available and easy to find for anyone in the organisation.
 
-2. Contributions over feature requests.
+2. Contributions over feature requests
 
 All stakeholders of a project act as potential contributors and are being
 treated and supported as such. Contributions remain suggestions instead of
@@ -109,39 +112,39 @@ for any newcomer to the project.
 
 Two caveats though:
 
-This does not replace structured documentation. It can serve as a starting point
+1. This does not replace structured documentation. It can serve as a starting point
 to collect structured documentation though.
 
-There are exceptions to the rule of everything being written and accessible to
+2. There are exceptions to the rule of everything being written and accessible to
 the entire organisation: People related discussions as well as security related
 discussions are sensitive and should not be held in public.
 
 6. Reward Trusted Committership
 
 All contributions (e.g. source code, documentation, bug reports, input to
-discussions, user support, marketing) are welcome. Contributions are welcome and
-are being rewarded. Those showing support for the project are being invited as
-Trusted Committers. All Trusted Committers of a project are published.
+discussions, user support, marketing) are welcome and are being rewarded. 
+Those showing support for the project are being invited as
+[Trusted Committers](../2-structured/trusted-committer.md). All Trusted Committers of a project are published.
 
 ## Resulting Context
 
-Members of the organisation understand which challenges they can address by
+* Organisation members understand which challenges they can address by
 applying InnerSource best practices.
 
-Organisation members lacking prior open source experience understand the basic
+* Organisation members lacking prior open source experience understand the basic
 values and principles of InnerSource projects.
 
-Organisation members lacking prior open source experience are able to check
+* Organisation members lacking prior open source experience are able to check
 their daily doing against a set of common established values.
 
-The organisation development practices move closer to open source projects thus
+* The organisation's development practices become more similar to open source projects thus
 making it easier for organisation members to participate in open source
 projects.
 
 ## Known Instances
 
-Europace AG
+* Europace AG (see also [Europace InnerSource Prinzipien](https://tech.europace.de/post/europace-inner-source-prinzipien/) (German))
 
 ## Status
 
-draft
+Initial

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -48,14 +48,21 @@ time deciding if what they are doing is inline with general InnerSource values.
 
 ## Solution
 
-Those that should adopt InnerSource need to understand two perspectives:
+Those driving the InnerSource initiative in the organisation need to help the teams and individuals that are lacking a deep background in open source, and therefore have a less intuitive understanding of InnerSource.
+
+Clarity should be provided around these two areas:
 
 ### Why does the organisation want to adopt InnerSource?
 
 In the past InnerSource has proven to be successful to solve several issues
-commonly found in organisations. Instead of going for generalizations, try to
-exactly identify the solutions that match the challenges of your organisation -
-preferably with those affected by the change you want to see.
+commonly found in organisations. 
+
+However which organizational challenges does your organization hope to improve
+upon using InnerSource?
+
+Instead of going for generalizations, try to exactly identify the solutions
+that match the challenges of your organisation - preferably with those affected
+by the change you want to see.
 
 Some challenges that others have addressed by following InnerSource
 best practices:
@@ -63,7 +70,7 @@ best practices:
 * Reduce development silos caused by excessive ownership culture.
 * Increase innovation speed by reducing time spent solving similar issues by
   fostering healthy code reuse.
-* Increase development speed by better cross team collaboration.
+* Increase development speed by better cross-team collaboration.
 * Solve project/ team dependencies beyond "wait it out" and "build workarounds",
   thereby reducing engineering bottlenecks.
 * Increase quality.
@@ -71,10 +78,10 @@ best practices:
 * To increase success of new hires.
 * To build actionable documentation.
 
-### Provide clear InnerSource principles
+### Which InnerSource principles will help to address these challenges?
 
-Once teams understand which problems InnerSource will help them address, the next
-step is to explain which principles help address these challenges.
+Once teams understand which problems InnerSource will help them address, the
+next step is to explain which principles help address these challenges.
 
 Based on basic open source development principles the following guidelines
 have been proven successful:

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -50,9 +50,9 @@ Those that should adopt InnerSource need to understand two perspectives:
 In the past InnerSource has proven to be successful to solve several issues
 commonly found in organisations. Instead of going for generalizations, try to
 exactly identify the solutions that match the challenges of your organisation -
-preferably with those affected by the change you want to see. 
+preferably with those affected by the change you want to see.
 
-Some challenges that others have addressed by following InnerSource 
+Some challenges that others have addressed by following InnerSource
 best practices:
 
 * Reduce development silos caused by excessive ownership culture.
@@ -69,9 +69,9 @@ best practices:
 ### Provide clear InnerSource principles
 
 Once teams understand which problems InnerSource will help them address, the next
-step is to explain which principles help address these challenges. 
+step is to explain which principles help address these challenges.
 
-Based on basic open source development principles the following guidelines 
+Based on basic open source development principles the following guidelines
 have been proven successful:
 
 (1) Code must be transparently hosted within the organisation

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -62,7 +62,6 @@ that others have addressed by following InnerSource best practices:
 * To increase success of new hires.
 * To build actionable documentation.
 
-
 ### Provide clear InnerSource principles
 
 Once teams understand which problems InnerSource will help them address the next
@@ -147,5 +146,4 @@ Europace AG
 ## Status
 
 draft
-
 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -19,7 +19,7 @@ transport the message of what InnerSource is, which problems it solves and which
 tools it uses for solving these issues. As a result InnerSource adoption in the
 organisation slows down. Teams develop diverging ideas of what the goals of InnerSource
 is about and how to best implement it leading to confusion when contributors
-are starting to cross team boundaries. 
+are starting to cross team boundaries.
 
 ## Story
 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -1,0 +1,153 @@
+## Title
+
+_Explicit InnerSource principles_
+
+## Patlet
+
+InnerSource as a term is circulating among employees. The usual explanation of
+"applying Open Source best practices inside an organisation" does not work well
+though with people lacking an Open Source background. As a remedy the most
+important principles of InnerSource get published widely.
+
+## Problem
+
+The organisation is trying to role out InnerSource at a larger scale. The
+initiative started among Open Source enthusiasts. The goal is now to get buy in
+from people that are lacking Open Source experience. As a result the typical
+slogan of "applying Open Source best practices" is not longer sufficient to
+transport the message of what InnerSource is, which problems it solves and which
+tools it uses for solving these issues.
+
+## Context
+
+In an organisation early experiments have shown that open source collaboration
+best practices can be beneficial. The goal now is to move the initiative to
+teams and individuals lacking a deep background in open source.
+
+The goal now is to clearly communicate the goals of the InnerSource initiative
+as well as a clear path towards achieving these goals.
+
+## Forces
+
+Teams have trouble communicating exactly what the important aspects of
+InnerSource are.
+
+People lacking open source experience fail to understand what it means to bring
+open source best practices into the organisation.
+
+On a daily basis teams trying to follow InnerSource best practices have a hard
+time deciding if what they are doing is inline with general InnerSource values.
+
+
+## Solution
+
+Those involved with the InnerSource initiative in the organisation need to
+understand two perspectives:
+
+### Why does the organisation want to adopt InnerSource?
+
+In the past InnerSource has proven to be successful to solve several issues
+commonly found in organisations. Instead of going for generalizations, try to
+exactly identify the solutions that match the challenges of your organisation -
+preferably with those affected by the change you want to see. Some challenges
+that others have addressed by following InnerSource best practices:
+
+* Reduce development silos caused by excessive ownership culture.
+* Increase innovation speed by reducing time spent solving similar issues by
+  fostering healthy code reuse.
+* Increase development speed by better cross team collaboration.
+* Solve project/ team dependencies beyond "wait it out" and "build workarounds",
+  thereby reducing engineering bottlenecks.
+* Increase quality.
+* Increase employee happiness.
+* To increase success of new hires.
+* To build actionable documentation.
+
+
+### Provide clear InnerSource principles
+
+Once teams understand which problems InnerSource will help them address the next
+step is to explain which basic values help address these challenges. Based on
+basic open source development principles the following guidelines have been
+proven successful:
+
+1. Code must be transparently hosted within the organisation.
+
+Source code, documentation, data relevant for project development must be
+available and easy to find for anyone in the organisation.
+
+2. Contributions over feature requests.
+
+All stakeholders of a project act as potential contributors and are being
+treated and supported as such. Contributions remain suggestions instead of
+requirements. Coordination before a contribution helps avoid wasted effort.
+Projects provide contribution guidelines to avoid friction.
+
+3. Mistakes are opportunities for learning
+
+With work visible across the entire organisation any mistake is visible to
+everyone. As a result a culture must be established in which mistakes are
+opportunities for learning instead of failure that should be avoided at all
+cost.
+
+4. Allow written advise to accrete in a persistent, searchable archive
+
+All project communication, in particular decisions taken and discussions leading
+up to those decisions need to be archived. It must be possible to reference
+communication via stable URLs. Previous communication needs to be stored in a
+way that can easily be searched.
+
+5. Written over verbal communication
+
+For projects that span multiple teams, potentially on diverging meeting
+schedules, it needs to be possible to collaborate asynchronously. The goal for
+InnerSource projects is to recruit new contributors. For that, potential future
+contributors need to be able to follow the project progress on a self serve
+basis with a very low barrier to entry. If project relevant communication
+happens through synchronous communication, arguments discussed need to be made
+transparent in the written channel - decisions should be finalized only there.
+As a side effect this leads to passive base documentation that is very valuable
+for any newcomer to the project.
+
+Two caveats though:
+
+This does not replace structured documentation. It can serve as a starting point
+to collect structured documentation though.
+
+There are exceptions to the rule of everything being written and accessible to
+the entire organisation: People related discussions as well as security related
+discussions are sensitive and should not be held in public.
+
+6. Reward Trusted Committership
+
+All contributions (e.g. source code, documentation, bug reports, input to
+discussions, user support, marketing) are welcome. Contributions are welcome and
+are being rewarded. Those showing support for the project are being invited as
+Trusted Committers. All Trusted Committers of a project are published.
+
+## Resulting Context
+
+Members of the organisation understand which challenges they can address by
+applying InnerSource best practices.
+
+Organisation members lacking prior open source experience understand the basic
+values and principles of InnerSource projects.
+
+Organisation members lacking prior open source experience are able to check
+their daily doing against a set of common established values.
+
+The organisation development practices move closer to open source projects thus
+making it easier for organisation members to participate in open source
+projects.
+
+
+## Known Instances
+
+Europace AG
+
+## Status
+
+draft
+
+
+

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -74,26 +74,26 @@ step is to explain which principles help address these challenges.
 Based on basic open source development principles the following guidelines 
 have been proven successful:
 
-1. Code must be transparently hosted within the organisation
+(1) Code must be transparently hosted within the organisation
 
 Source code, documentation, data relevant for project development must be
 available and easy to find for anyone in the organisation.
 
-2. Contributions over feature requests
+(2) Contributions over feature requests
 
 All stakeholders of a project act as potential contributors and are being
 treated and supported as such. Contributions remain suggestions instead of
 requirements. Coordination before a contribution helps avoid wasted effort.
 Projects provide contribution guidelines to avoid friction.
 
-3. Mistakes are opportunities for learning
+(3) Mistakes are opportunities for learning
 
 With work visible across the entire organisation any mistake is visible to
 everyone. As a result a culture must be established in which mistakes are
 opportunities for learning instead of failure that should be avoided at all
 cost.
 
-4. Written over verbal communication
+(4) Written over verbal communication
 
 For projects that span multiple teams, potentially on diverging meeting
 schedules, it needs to be possible to collaborate asynchronously. The goal for
@@ -105,7 +105,7 @@ transparent in the written channel - decisions should be finalized only there.
 As a side effect this leads to passive base documentation that is very valuable
 for any newcomer to the project.
 
-5. Allow written advise to accumulate in a persistent, searchable archive
+(5) Allow written advise to accumulate in a persistent, searchable archive
 
 All project communication, in particular decisions taken and discussions leading
 up to those decisions need to be archived. It must be possible to reference
@@ -121,7 +121,7 @@ to collect structured documentation though.
 the entire organisation: People related discussions as well as security related
 discussions are sensitive and should not be held in public.
 
-6. Reward Trusted Committership
+(6) Reward Trusted Committership
 
 All contributions (e.g. source code, documentation, bug reports, input to
 discussions, user support, marketing) are welcome and are being rewarded. 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -16,7 +16,7 @@ initiative started among open source enthusiasts. The goal is now to get buy-in
 from people that are lacking open source experience. For that audience the typical
 slogan of "applying open source best practices" is no longer sufficient to
 transport the message of what InnerSource is, which problems it solves and which
-tools it uses for solving these issues. As a result InnerSource adoption in the 
+tools it uses for solving these issues. As a result InnerSource adoption in the
 organisation slows down. Teams develop diverging ideas of what the goals of InnerSource
 is about and how to best implement it leading to confusion when contributors
 are starting to cross team boundaries. 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -145,7 +145,7 @@ projects.
 
 ## Known Instances
 
-* Europace AG (see also [Europace InnerSource Prinzipien](https://tech.europace.de/post/europace-inner-source-prinzipien/) (German))
+* Europace AG - see also [Europace InnerSource Prinzipien](https://tech.europace.de/post/europace-inner-source-prinzipien/) (German)
 
 ## Status
 

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -24,7 +24,7 @@ are starting to cross team boundaries.
 ## Story
 
 Early experiments in an organisation have shown that open source collaboration
-best practices can be beneficial. The goal now is to move the initiative to
+best practices can be beneficial. The next step now is to move the initiative to
 teams and individuals lacking a deep background in open source.
 
 The goal now is to clearly communicate the goals of the InnerSource initiative

--- a/patterns/1-initial/principles.md
+++ b/patterns/1-initial/principles.md
@@ -124,7 +124,7 @@ discussions are sensitive and should not be held in public.
 (6) Reward Trusted Committership
 
 All contributions (e.g. source code, documentation, bug reports, input to
-discussions, user support, marketing) are welcome and are being rewarded. 
+discussions, user support, marketing) are welcome and are being rewarded.
 Those showing support for the project are being invited as
 [Trusted Committers](../2-structured/trusted-committer.md). All Trusted Committers of a project are published.
 


### PR DESCRIPTION
Several months ago there was a discussion at the InnerSource commons to come up with an InnerSource manifesto. We never came to a final version of that document. However an early version of it was used over at [Europace](https://neu.europace.de/) to come up with a list of [common InnerSource principles](https://tech.europace.de/post/europace-inner-source-prinzipien/).

Maybe this pattern can serve as a starting point for re-starting the discussion on a common InnerSource manifesto.
 