### PR TITLE
Template for future Board reports

### DIFF
--- a/meta/boardreports/_template.md
+++ b/meta/boardreports/_template.md
@@ -1,0 +1,36 @@
+# Quarterly Report for Governance Meeting
+
+*Reminder: The report should not exceed half a page*
+
+## Summary (mandatory)
+
+| Key Fact |  |
+| ------------- | ------------- |
+| Working Group | *The name of your working group e.g. Patterns* |
+| Reporting Period | *e.g. Feb/March/April 2021* |
+| Mission | *Briefly describe what your project does.* |
+| Last Committer Addition | *When was the last committer added to the project (which date)? A healthy project tends to add new committers regularly.* |
+
+## Project/Community Status and Health (mandatory)
+
+*Sum up the status and health of your project and community in a few sentences.*
+
+## Project Activity (mandatory)
+
+*Describe the overall activity in the project over the past quarter.*
+
+## Committer Diversity (mandatory if no committer addition recently)
+
+*A healthy project should survive the departure of any single contributor or employer of contributors. To achieve that it needs a sufficient amount of committer diversity. How do you make sure that people from all regions on the globe can participate in your project without having to be awake at midnight their local time?*
+
+## Plans of the Project (optional)
+
+*Describe the current plans of the project. Include goals the project is working towards as well as any announcements that should be published through the Marketing working group.*
+
+## Other Needs (optional)
+
+*Are their any project branding or naming issues, either in the project or externally? Any legal issues? Any infrastructure or strategic needs?*
+
+## Issue for the Board (optional)
+
+*Are there any issues for the Board to act on?*

--- a/meta/boardreports/_template.md
+++ b/meta/boardreports/_template.md
@@ -1,6 +1,6 @@
 # Quarterly Report for Governance Meeting
 
-*Reminder: The report should not exceed half a page*
+Reminder: The report should not exceed half a page
 
 ## Summary (mandatory)
 
@@ -13,24 +13,28 @@
 
 ## Project/Community Status and Health (mandatory)
 
-*Sum up the status and health of your project and community in a few sentences.*
+Sum up the status and health of your project and community in a few sentences.
 
 ## Project Activity (mandatory)
 
-*Describe the overall activity in the project over the past quarter.*
+Describe the overall activity in the project over the past quarter.
 
-## Committer Diversity (mandatory if no committer addition recently)
+## Committer Diversity (mandatory if no Committer was added recently)
 
-*A healthy project should survive the departure of any single contributor or employer of contributors. To achieve that it needs a sufficient amount of committer diversity. How do you make sure that people from all regions on the globe can participate in your project without having to be awake at midnight their local time?*
+In the Patterns Working Group we interpret the term **Committer** here in the sense of [Trusted Committer](../../TRUSTED-COMMITTERS.md).
+
+A healthy project should survive the departure of any single contributor or employer of contributors. To achieve that it needs a sufficient amount of committer diversity. 
+
+How do you make sure that people from all regions on the globe can participate in your project without having to be awake at midnight their local time?
 
 ## Plans of the Project (optional)
 
-*Describe the current plans of the project. Include goals the project is working towards as well as any announcements that should be published through the Marketing working group.*
+Describe the current plans of the project. Include goals the project is working towards as well as any announcements that should be published through the Marketing working group.
 
 ## Other Needs (optional)
 
-*Are their any project branding or naming issues, either in the project or externally? Any legal issues? Any infrastructure or strategic needs?*
+Are their any project branding or naming issues, either in the project or externally? Any legal issues? Any infrastructure or strategic needs?
 
 ## Issue for the Board (optional)
 
-*Are there any issues for the Board to act on?*
+Are there any issues for the Board to act on?

--- a/meta/boardreports/_template.md
+++ b/meta/boardreports/_template.md
@@ -23,7 +23,7 @@ Describe the overall activity in the project over the past quarter.
 
 In the Patterns Working Group we interpret the term **Committer** here in the sense of [Trusted Committer](../../TRUSTED-COMMITTERS.md).
 
-A healthy project should survive the departure of any single contributor or employer of contributors. To achieve that it needs a sufficient amount of committer diversity. 
+A healthy project should survive the departure of any single contributor or employer of contributors. To achieve that it needs a sufficient amount of committer diversity.
 
 How do you make sure that people from all regions on the globe can participate in your project without having to be awake at midnight their local time?
 


### PR DESCRIPTION
I added a template for Board reports of the Patterns working group.

The goal of this is to:
a) make it easier for others to write these report
b) by suggesting a specific format, keeping the report fairly short (~half a page)

I hope that the formatting will keep it short based on this reasoning:
- only 3 mandatory blocks in total
- the first block with the Summary contain key facts in a table format (which makes it unlikely for people to put a lot of text in there)

