### PR TITLE
Run link checker action daily

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 8 * * *'
+    - cron:  '30 8 * * *'
 
 jobs:
   linkChecker:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "main"
   pull_request:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 8 * * *'
 
 jobs:
   linkChecker:


### PR DESCRIPTION
Run link checker action daily, so that we catch broken links quickly.
Especially important to catch and fix links in the book (Patterns Level 2+3).

Also see: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
