### PR TITLE
Adding new page to make it easier to find the mindmap

### DIFF
--- a/book/explore-patterns.md
+++ b/book/explore-patterns.md
@@ -4,13 +4,15 @@ More and more patterns are contributed to this book by the InnerSource Commons c
 
 Now how to make it easy for readers to discover the patterns that can help them in their particular situation?
 
-For this purpose we provide this mind map. It categorizes patterns based on the different phases of an InnerSource Program, and the challenges that might appear in the respective phases.
+For this purpose we provide this mind map. It **categorizes patterns based on the different phases of an InnerSource Program**, and the challenges that might appear in the respective phases.
 
 <img src="./innersource-program-mind-map.png" title="InnerSource Patterns as a Mind Map">
 
 ## Improve this Mind Map
 
-If you have other ideas for improving the discoverability of our patterns, or want to help us to improve this mind map, take a look at the documentation of our [Pattern Categorization](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/main/pattern-categorization/README.md) approach, and also check how to [contribute to this book](contribute.md).
+If you notice anything in this mind map that looks wrong, please [open an issue](https://github.com/InnerSourceCommons/InnerSourcePatterns/issues), describing the problem and the fix that should be made.
+
+Further if you have other ideas for improving the discoverability of these patterns, or want to make this mind map better, review the documentation of our [Pattern Categorization](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/main/pattern-categorization/README.md) approach, and also check how to [contribute to this book](contribute.md).
 
 ## References
 

--- a/book/explore-patterns.md
+++ b/book/explore-patterns.md
@@ -1,0 +1,17 @@
+# Explore Patterns
+
+More and more patterns are contributed to this book by the InnerSource Commons community. That is awesome!
+
+Now how to make it easy for readers to discover the patterns that can help them in their particular situation?
+
+For this purpose we provide this mind map. It categorizes patterns based on the different phases of an InnerSource Program, and the challenges that might appear in the respective phases.
+
+<img src="./innersource-program-mind-map.png" title="InnerSource Patterns as a Mind Map">
+
+## Improve this Mind Map
+
+If you have other ideas for improving the discoverability of our patterns, or want to help us to improve this mind map, take a look at the documentation of our [Pattern Categorization](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/main/pattern-categorization/README.md) approach, and also check how to [contribute to this book](contribute.md).
+
+## References
+
+The idea for categorizing patterns like this is loosely based a description in [Thoughts on an InnerSource Pattern Language](https://drive.google.com/file/d/13AY8glCOdpLOVuz7cVD6QOB8d2xbHCS1/view) by Tim Yao, Bob Hanmer and Padma Sudarsan (2018). For specifics see slide 15 in that slide deck.

--- a/book/toc_template.md
+++ b/book/toc_template.md
@@ -11,7 +11,7 @@ Instead edit toc_template.md
 # Table of Contents
 
 * [Table of Contents](../book/toc.md)
-* [Explore Patterns[](../book/contribute.md)
+* [Explore Patterns[](../book/explore-patterns.md)
 * [Contribute to this book](../book/contribute.md)
 
 <img src="./innersource-program-mind-map.png" title="InnerSource Patterns as a Mind Map">

--- a/book/toc_template.md
+++ b/book/toc_template.md
@@ -11,6 +11,7 @@ Instead edit toc_template.md
 # Table of Contents
 
 * [Table of Contents](../book/toc.md)
+* [Explore Patterns[](../book/contribute.md)
 * [Contribute to this book](../book/contribute.md)
 
 <img src="./innersource-program-mind-map.png" title="InnerSource Patterns as a Mind Map">


### PR DESCRIPTION
We got some feedback that the [mindmap](https://patterns.innersourcecommons.org/toc) in our patterns book is really useful but a bit hard to find.

This PR is adding a new dedicated page to the book that highlights the mind map, and also provides some more context as to why we chose the mind map approach in the first place.


 