### PR TITLE
Update activity score calculation algorithm

### DIFF
--- a/patterns/2-structured/repository-activity-score.md
+++ b/patterns/2-structured/repository-activity-score.md
@@ -65,14 +65,14 @@ function calculateScore(repo) {
 
     // updated in last 3 months: adds a bonus multiplier between 0..1 to overall score (1 = updated today, 0 = updated more than 100 days ago)
     let iDaysSinceLastUpdate = (new Date().getTime() - new Date(repo.updated_at).getTime()) / 1000 / 86400;
-    iScore = iScore * ((100 - Math.min(iDaysSinceLastUpdate, 100)) / 100);
+    iScore = iScore * ((1 + (100 - Math.min(iDaysSinceLastUpdate, 100))) / 100);
 
     // evaluate participation stats for the previous  3 months
     repo._InnerSourceMetadata = repo._InnerSourceMetadata || {};
     if (repo._InnerSourceMetadata.participation) {
         // average commits: adds a bonus multiplier between 0..1 to overall score (1 = >10 commits per week, 0 = less than 3 commits per week)
         let iAverageCommitsPerWeek = repo._InnerSourceMetadata.participation.slice(repo._InnerSourceMetadata.participation.length - 13).reduce((a, b) => a + b) / 13;
-        iScore = iScore * ((Math.min(Math.max(iAverageCommitsPerWeek - 3, 0), 7)) / 7);
+        iScore = iScore * ((1 + (Math.min(Math.max(iAverageCommitsPerWeek - 3, 0), 7))) / 7);
     }
 
     // boost calculation:

--- a/patterns/2-structured/repository-activity-score.md
+++ b/patterns/2-structured/repository-activity-score.md
@@ -58,7 +58,10 @@ function calculateScore(repo) {
     // initial score is 50 to give active repos with low GitHub KPIs (forks, watchers, stars) a better starting point
     let iScore = 50;
     // weighting: forks and watches count most, then stars, add some little score for open issues, too
-    iScore += repo.forks_count * 5 + (repo.subscribers_count ? repo.subscribers_count : 0) + repo.stargazers_count / 3 + repo.open_issues_count / 5;
+    iScore += repo.forks_count * 5;
+    iScore += (repo.subscribers_count ? repo.subscribers_count : 0);
+    iScore += repo.stargazers_count / 3;
+    iScore += repo.open_issues_count / 5;
     let iDaysSinceLastUpdate = (new Date().getTime() - new Date(repo.updated_at).getTime()) / 1000 / 86400;
     // updated in last 3 months: adds a bonus multiplier between 0..1 to overall score (1 = updated today, 0 = updated more than 100 days ago)
     iScore = iScore * (1 + (100 - Math.min(iDaysSinceLastUpdate, 100)) / 100);

--- a/patterns/2-structured/repository-activity-score.md
+++ b/patterns/2-structured/repository-activity-score.md
@@ -58,7 +58,7 @@ function calculateScore(repo) {
     // initial score is 50 to give active repos with low GitHub KPIs (forks, watchers, stars) a better starting point
     let iScore = 50;
     // weighting: forks and watches count most, then stars, add some little score for open issues, too
-    iScore += repo["forks_count"] * 5 + repo["watchers_count"] + repo["stargazers_count"] / 3 + repo["open_issues_count"] / 5;
+    iScore += repo.forks_count * 5 + (repo.subscribers_count ? repo.subscribers_count : 0) + repo.stargazers_count / 3 + repo.open_issues_count / 5;
     let iDaysSinceLastUpdate = (new Date().getTime() - new Date(repo.updated_at).getTime()) / 1000 / 86400;
     // updated in last 3 months: adds a bonus multiplier between 0..1 to overall score (1 = updated today, 0 = updated more than 100 days ago)
     iScore = iScore * (1 + (100 - Math.min(iDaysSinceLastUpdate, 100)) / 100);
@@ -66,7 +66,7 @@ function calculateScore(repo) {
     repo._InnerSourceMetadata = repo._InnerSourceMetadata || {};
     if (repo._InnerSourceMetadata.participation) {
         // average commits: adds a bonus multiplier between 0..1 to overall score (1 = >10 commits per week, 0 = less than 3 commits per week)
-        let iAverageCommitsPerWeek = repo._InnerSourceMetadata.participation.slice(repo._InnerSourceMetadata.participation - 13).reduce((a, b) => a + b) / 13;
+        let iAverageCommitsPerWeek = repo._InnerSourceMetadata.participation.slice(13).reduce((a, b) => a + b) / 13;
         iScore = iScore * (1 + (Math.min(Math.max(iAverageCommitsPerWeek - 3, 0), 7)) / 7);
     }
     // boost calculation:
@@ -78,9 +78,9 @@ function calculateScore(repo) {
     // add boost to score
     iScore += iBoost;
     // give projects with a meaningful description a static boost of 50
-    iScore += (repo["_InnerSourceMetadata"]["description"].length > 30 || repo["_InnerSourceMetadata"] && repo["_InnerSourceMetadata"]["motivation"].length > 30 ? 50 : 0);
+    iScore += (repo.description?.length > 30 || repo._InnerSourceMetadata.motivation?.length > 30 ? 50 : 0);
     // give projects with contribution guidelines (CONTRIBUTING.md) file a static boost of 100
-    iScore += (repo["_InnerSourceMetadata"] && repo["_InnerSourceMetadata"]["guidelines"] ? 100 : 0);
+    iScore += (repo._InnerSourceMetadata.guidelines ? 100 : 0);
     // build in a logarithmic scale for very active projects (open ended but stabilizing around 5000)
     if (iScore > 3000) {
         iScore = 3000 + Math.log(iScore) * 100;

--- a/patterns/2-structured/repository-activity-score.md
+++ b/patterns/2-structured/repository-activity-score.md
@@ -62,16 +62,19 @@ function calculateScore(repo) {
     iScore += (repo.subscribers_count ? repo.subscribers_count : 0);
     iScore += repo.stargazers_count / 3;
     iScore += repo.open_issues_count / 5;
-    let iDaysSinceLastUpdate = (new Date().getTime() - new Date(repo.updated_at).getTime()) / 1000 / 86400;
+
     // updated in last 3 months: adds a bonus multiplier between 0..1 to overall score (1 = updated today, 0 = updated more than 100 days ago)
-    iScore = iScore * (1 + (100 - Math.min(iDaysSinceLastUpdate, 100)) / 100);
+    let iDaysSinceLastUpdate = (new Date().getTime() - new Date(repo.updated_at).getTime()) / 1000 / 86400;
+    iScore = iScore * ((100 - Math.min(iDaysSinceLastUpdate, 100)) / 100);
+
     // evaluate participation stats for the previous  3 months
     repo._InnerSourceMetadata = repo._InnerSourceMetadata || {};
     if (repo._InnerSourceMetadata.participation) {
         // average commits: adds a bonus multiplier between 0..1 to overall score (1 = >10 commits per week, 0 = less than 3 commits per week)
-        let iAverageCommitsPerWeek = repo._InnerSourceMetadata.participation.slice(13).reduce((a, b) => a + b) / 13;
-        iScore = iScore * (1 + (Math.min(Math.max(iAverageCommitsPerWeek - 3, 0), 7)) / 7);
+        let iAverageCommitsPerWeek = repo._InnerSourceMetadata.participation.slice(repo._InnerSourceMetadata.participation.length - 13).reduce((a, b) => a + b) / 13;
+        iScore = iScore * ((Math.min(Math.max(iAverageCommitsPerWeek - 3, 0), 7)) / 7);
     }
+
     // boost calculation:
     // all repositories updated in the previous year will receive a boost of maximum 1000 declining by days since last update
     let iBoost = (1000 - Math.min(iDaysSinceLastUpdate, 365) * 2.74);
@@ -92,6 +95,7 @@ function calculateScore(repo) {
     iScore = Math.round(iScore - 50);
     // add score to metadata on the fly
     repo._InnerSourceMetadata.score = iScore;
+
     return iScore;
 }
 ```


### PR DESCRIPTION
This PR contains changes to the [Repository Activity Score](https://patterns.innersourcecommons.org/p/repository-activity-score) algorithm.

* replace `watchers_count` by `subscribers_count` - because stars are the same as watchers, so I just kept stargazers and replaced watchers by subscribers (read more about this [here](https://docs.github.com/en/rest/reference/activity#starring-vs-watching)).
* fix slice number - I'm not a JS pro, but seems that we just want to slice the 13 (~3 months)
* simplify check - some validations can be made by just add the `?`
* repo JSON access standardization - JS versatility allow using `json['prop']` or json.prop. I picked one for better reading.
