### PR TITLE
New Pattern: Core Team

### DIFF
--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -4,8 +4,7 @@ Core Team
 
 ## Patlet
 
-Is your InnerSource project difficult for people to work with,
-yet no one is interested in making it better?
+Is your InnerSource project difficult for people to work with, yet no one is interested in improving it?
 Establish a core team to take care of those fundamental items so that contributors can focus on adding features that provide value to them.
 
 ## Problem
@@ -77,44 +76,15 @@ Continual focus on these metrics and effort to help them improve will naturally 
 
 ## Rationale
 
-Separating out a core team and tasking them in this way 
+Separating out a core team and tasking them in this way helps to fill the gaps that a successful project needs yet are left behind by contributors that are pursuing their own agenda only.
+The core team fills the gaps and greases the wheels so that the contribution ecosystem remains healthy.
 
-Explains why this is the right solution; using totally different words WHY this solution balances these forces and this context to solve this problem.
-Can expand on what-if's or theories.
+## Known Instances
 
-## Known Instances (optional)
+Nike implented this pattern to manage the InnerSource effort around its reusable CI/CD pipelines.
 
-Where has this been seen before?
-Helps to reinforce that this is a REAL pattern and that you match the context.
+## Author
 
-May mention:
-
-* A particular business
-* Anonymized instances ex: "3 companies have proven that this is a good solution" or "A large financial services org...".
-
-## Status (optional until merging)
-
-General pattern status is stored in GitHub's Label tagging - see any pull request.
-Note that this GitHub label tagging becomes less visible once the pattern is finalized and merged, so having some information in this field is helpful.
-
-You might store other related info here, such as review history: "Three of us reviewed this on 2/5/17 and it needs John's expertise before it can go further."
-
-## Author(s) (optional)
-
-Often, this is yourself;
-If you need to, find someone in the InnerSource Commons to be the nominal author (As Told To);
-Could also be no-one if you do not want to take on authorship (common with a donut looking for a solution)
-
-## Acknowledgements (optional)
-
-Include those who assisted in helping with this pattern - both for attribution and for possible future follow up.
-Though optional, most patterns should list who helped in their creation.
-
-## Alias (optional)
-
-If this pattern is also known under a different name than what is listed unter **Title**, please list those alternative titles here.
-e.g. if the pattern is named after the problem it solves, a helpful alias might be one that describes the solution that is applied.
-
+[Russell R. Rutledge](https://github.com/rrrutledge)
 
 [Trusted Committers]: https://patterns.innersourcecommons.org/p/trusted-committer
-[Trusted Committer]: https://patterns.innersourcecommons.org/p/trusted-committer

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -4,8 +4,9 @@ Core Team
 
 ## Patlet
 
-Is your InnerSource project difficult for people to work with, yet no one is interested in improving it?
-Establish a core team to take care of the project's fundamental items so that contributors are enabled to add and use the features that provide value to their scenarios.
+Even when an InnerSource project is widely needed, contributions and usage may be stymied because the project is difficult to work with.
+Establish a core team that is dedicated to take care of the project's fundamental items.
+Their work enables contributors to add and use the features that provide value to their scenarios.
 
 ## Problem
 
@@ -26,14 +27,15 @@ Some possible causes:
 There's a central project that everyone depends on.
 What a great candidate for InnerSource!
 Unfortunately, the project has grown organically, with various contributions and additions slapped on haphazardly.
-Now it's an icky, black morass of code that no one understands and everyone is afraid to touch.
-It's clearly due for an overhaul, but even though everyone needs that and wants it, no one takes the time to work on it.
+Now it's an icky, thick morass of code that no one understands and everyone is afraid to touch.
+It's clearly due for an overhaul (e.g. refactoring, testing, documentation, etc.), but even though everyone needs and wants that work, no one takes the time to do it.
 
 ## Context
 
-* Many teams use the project.
+* Many teams need the project.
 * Significant tech debt.
 * Slow adoption and iteration on the project.
+* Nobody is taking reponsibility for the project and contribution ecosystem as a whole.
 
 ## Forces
 
@@ -43,8 +45,7 @@ It's clearly due for an overhaul, but even though everyone needs that and wants 
 
 ## Solution
 
-Form a core team whose job it is to maintain the project in a state so that others can easily onboard and contribute to it.
-This core team does the work that is necessary for a healthy usage and contribution ecosystem.
+Form a core team whose job it is to maintain this project in a state so that others can easily onboard and contribute to it.This core team does the work that is necessary for a healthy usage and contribution ecosystem.
 This critical work tends to not be prioritized as a contribution.
 Catogories of this type of work include communication, local environment, and devops infrastructure.
 
@@ -63,6 +64,10 @@ Here are some specific examples:
 
 Each of these items is very important to a healthy product ecosystem, yet is unlikely to be prioritized as a contribution.
 
+The core team may be composed of a small number of people on a full-time or a part-time basis.
+The choice depends on the amount of work needed, the availibility of resources, and the culture of the organization.
+The most important consideration is to form the team in a way that allows the organization to empower and hold them accountable in the same way as any other team.
+
 Due to their central role, core team members should nearly always fill the role of [Trusted Committers] as well.
 While the [Trusted Committer] role focuses mostly on facilitating others' contribution and use of the project, a core team member regularly contributes to the project as well.
 The core team doesn't have its own business agenda that determines its contibutions.
@@ -77,8 +82,8 @@ Continual focus on these metrics will naturally drive the core team to prioritiz
 
 ## Resulting Context
 
-* Many teams use and contribute to the project.
 * It is easy to use and contribute to the project.
+* Many teams use and contribute to the project.
 * Core team has their success defined in terms of others' interaction with and response to their project.
 
 ## Rationale

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -67,6 +67,7 @@ The core team doesn't have its own business agenda that determines its contibuti
 They decide what to contribute based on what will most help others to use and contribute to the project.
 
 A good way to continually remind the core team of this goal is to have them report regularly on:
+
 * number of active teams using the project
 * number of off-team contributions to the project.
 

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -66,9 +66,10 @@ While the [Trusted Committer] role focuses mostly on facilitating others' contri
 The core team doesn't have its own business agenda that determines its contibutions.
 They decide what to contribute based on what will most help others to use and contribute to the project.
 
-A good way to continually remind the core team of this goal is to have them report regularly on
+A good way to continually remind the core team of this goal is to have them report regularly on:
 * number of active teams using the project
 * number of off-team contributions to the project.
+
 Continual focus on these metrics will naturally drive the core team to prioritize generally the right work to create a thriving InnerSource ecosystem around the project.
 
 ## Resulting Context

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -1,0 +1,87 @@
+## Title
+
+Core Team
+
+## Patlet
+
+Is your InnerSource project difficult for people to work with,
+yet no one is interested in making it better?
+Establish a core team to take care of the fundamental tasks so that contributors can focus on adding what provides value to them.
+
+## Problem
+
+
+What is the problem - crisp definition of the problem
+Short description, usually not more than a couple sentences, that describes what the issues and challenges are.
+Be careful not to morph into information found in other sections below.
+
+## Story (optional)
+
+Sometimes there is a story that helps people understand the pattern better.
+
+## Context
+
+Where does the problem exist?
+What are the pre-conditions?
+**Unchangeable** before the solution goes into place.
+The content here is often tied to the applicability of the pattern for other readers: "Do I have this same particular situation?"
+
+## Forces
+
+What makes the problem difficult?
+What are the trade-offs?
+These are constraints that **can be changed** at a cost.
+The solution might change one or more of these forces in order to solve the problem, while also in-turn changing the context.
+
+## Sketch (optional)
+
+visual illustration
+
+## Solutions
+
+Verified resolutions and possible resolutions to the problem.
+
+## Resulting Context
+
+What is the situation after the problem has been solved?
+The original context is changed indirectly by way of the solution.
+Often this section can include discussion of the next possible Patterns/problems introduced.
+This section can be short in content - the solution may not introduce new problems or change much context.
+
+## Rationale (optional)
+
+Explains why this is the right solution; using totally different words WHY this solution balances these forces and this context to solve this problem.
+Can expand on what-if's or theories.
+
+## Known Instances (optional)
+
+Where has this been seen before?
+Helps to reinforce that this is a REAL pattern and that you match the context.
+
+May mention:
+
+* A particular business
+* Anonymized instances ex: "3 companies have proven that this is a good solution" or "A large financial services org...".
+
+## Status (optional until merging)
+
+General pattern status is stored in GitHub's Label tagging - see any pull request.
+Note that this GitHub label tagging becomes less visible once the pattern is finalized and merged, so having some information in this field is helpful.
+
+You might store other related info here, such as review history: "Three of us reviewed this on 2/5/17 and it needs John's expertise before it can go further."
+
+## Author(s) (optional)
+
+Often, this is yourself;
+If you need to, find someone in the InnerSource Commons to be the nominal author (As Told To);
+Could also be no-one if you do not want to take on authorship (common with a donut looking for a solution)
+
+## Acknowledgements (optional)
+
+Include those who assisted in helping with this pattern - both for attribution and for possible future follow up.
+Though optional, most patterns should list who helped in their creation.
+
+## Alias (optional)
+
+If this pattern is also known under a different name than what is listed unter **Title**, please list those alternative titles here.
+e.g. if the pattern is named after the problem it solves, a helpful alias might be one that describes the solution that is applied.

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -94,7 +94,7 @@ The core team fills those gaps and greases the wheels so that the contribution e
 
 ## Known Instances
 
-Nike implented this pattern to manage the InnerSource effort around its reusable CI/CD pipelines.
+Nike implemented this pattern to manage the InnerSource effort around its reusable CI/CD pipelines.
 
 ## Status
 

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -33,7 +33,7 @@ It's clearly due for an overhaul (e.g. refactoring, testing, documentation, etc.
 ## Context
 
 * Many teams need the project.
-* Significant tech debt.
+* The project has significant tech debt.
 * Slow adoption and iteration on the project.
 * Nobody is taking reponsibility for the project and contribution ecosystem as a whole.
 

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -45,7 +45,8 @@ It's clearly due for an overhaul (e.g. refactoring, testing, documentation, etc.
 
 ## Solution
 
-Form a core team whose job it is to maintain this project in a state so that others can easily onboard and contribute to it.This core team does the work that is necessary for a healthy usage and contribution ecosystem.
+Form a core team whose job it is to maintain this project in a state so that others can easily onboard and contribute to it.
+This core team does the work that is necessary for a healthy usage and contribution ecosystem.
 This critical work tends to not be prioritized as a contribution.
 Catogories of this type of work include communication, local environment, and devops infrastructure.
 

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -87,6 +87,10 @@ The core team fills those gaps and greases the wheels so that the contribution e
 
 Nike implented this pattern to manage the InnerSource effort around its reusable CI/CD pipelines.
 
+## Status
+
+Structured
+
 ## Author
 
 [Russell R. Rutledge](https://github.com/rrrutledge)

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -6,49 +6,78 @@ Core Team
 
 Is your InnerSource project difficult for people to work with,
 yet no one is interested in making it better?
-Establish a core team to take care of the fundamental tasks so that contributors can focus on adding what provides value to them.
+Establish a core team to take care of those fundamental items so that contributors can focus on adding features that provide value to them.
 
 ## Problem
 
+* It is difficult to contribute to the project.
+This could be due to things like:
+  * Can't run the project locally.
+  * Poor documentation.
+  * Convoluted code.
+  * Lack of adequate testing.
+* It is difficult to use the project.
+Some possible causes:
+  * Poor documentation (again).
+  * Frequent bugs.
+  * Unintuitive setup.
 
-What is the problem - crisp definition of the problem
-Short description, usually not more than a couple sentences, that describes what the issues and challenges are.
-Be careful not to morph into information found in other sections below.
+## Story
 
-## Story (optional)
-
-Sometimes there is a story that helps people understand the pattern better.
+There's a central project that everyone depends on.
+What a great candidate for InnerSource!
+Unfortunately, the project has grown organically, with various contributions and additions just slapped on.
+Now it's an icky, black morass of code that no one understands and everyone is afraid to touch.
+It's clearly due for an overhaul, but even though everyone needs it and wants it, no one takes the time to work on it.
 
 ## Context
 
-Where does the problem exist?
-What are the pre-conditions?
-**Unchangeable** before the solution goes into place.
-The content here is often tied to the applicability of the pattern for other readers: "Do I have this same particular situation?"
+* Project is full of tech debt.
+* Many teams use the project.
+* Tech debt slows adoption and iteration on the project.
 
 ## Forces
 
-What makes the problem difficult?
-What are the trade-offs?
-These are constraints that **can be changed** at a cost.
-The solution might change one or more of these forces in order to solve the problem, while also in-turn changing the context.
+* Everyone is busy.
+* Each contributing team prioritizes work that results in an immediate payoff for that team.
+* As the project grows the natural trend is for the project to become more difficult to use and to modify.
 
-## Sketch (optional)
+## Solution
 
-visual illustration
+Form a core team whose job it is to maintain the project in a state so that others can easily onboard to it and contribute to it.
+This core team does the work that is necessary for a healthy usage and contribution ecosystem yet tends to be work that is not prioritized as a contribution.
+Some main catogories of this type of work include communication, local environment, and devops infrastructure.
+Here are some specific examples:
+* Production bugs
+* Documentation.
+* Onboarding tutorials and examples.
+* Automated testing.
+* CI/CD.
+* Local environment.
+* Modularization.
+* Versioning.
+* Monitoring.
+* Trailblazing new classes/categories of features.
 
-## Solutions
+Each of these items is very important to a healthy product ecosystem, yet is unlikely to be prioritized regularly as a contribution.
 
-Verified resolutions and possible resolutions to the problem.
+Due to their central role, core team members should nearly always be [Trusted Committers](https://patterns.innersourcecommons.org/p/trusted-committer) as well.
+While the [Trusted Committer] focuses mostly on facilitating others' contribution and use of the project, a core team member regularly contributes to the project as well.
+The core team doesn't have its own business agenda that determines its contibutions.
+They decide what to contribute based on what will most help others to use and contribute to the project.
+
+A good way to continually remind the core team of this goal is to have them report regularly on the number of active teams using the project and the number of off-team contributions to the project.
+Continual focus on these metrics and effort to help them improve will naturally drive the core team to prioritize generally the right work to create a thriving InnerSource ecosystem around their project.
 
 ## Resulting Context
 
-What is the situation after the problem has been solved?
-The original context is changed indirectly by way of the solution.
-Often this section can include discussion of the next possible Patterns/problems introduced.
-This section can be short in content - the solution may not introduce new problems or change much context.
+* Many teams use and contribute to the project.
+* It is easy to use and contribute to the project.
+* Core team has their success defined in terms of others' interaction with and response to their project.
 
-## Rationale (optional)
+## Rationale
+
+Separating out a core team and tasking them in this way 
 
 Explains why this is the right solution; using totally different words WHY this solution balances these forces and this context to solve this problem.
 Can expand on what-if's or theories.
@@ -85,3 +114,7 @@ Though optional, most patterns should list who helped in their creation.
 
 If this pattern is also known under a different name than what is listed unter **Title**, please list those alternative titles here.
 e.g. if the pattern is named after the problem it solves, a helpful alias might be one that describes the solution that is applied.
+
+
+[Trusted Committers]: https://patterns.innersourcecommons.org/p/trusted-committer
+[Trusted Committer]: https://patterns.innersourcecommons.org/p/trusted-committer

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -39,8 +39,7 @@ It's clearly due for an overhaul (e.g. refactoring, testing, documentation, etc.
 
 ## Forces
 
-* Everyone is busy.
-* Each contributing team prioritizes work that results in an immediate payoff for that team.
+* Every contributing team is busy, and therefore prioritizes work that results in an immediate payoff for themselves.
 * As the project grows the natural trend is for it to become more difficult to use and to modify.
 
 ## Solution

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -48,7 +48,7 @@ It's clearly due for an overhaul (e.g. refactoring, testing, documentation, etc.
 Form a core team whose job it is to maintain this project in a state so that others can easily onboard and contribute to it.
 This core team does the work that is necessary for a healthy usage and contribution ecosystem.
 This critical work tends to not be prioritized as a contribution.
-Catogories of this type of work include communication, local environment, and devops infrastructure.
+Categories of this type of work include communication, local environment, and DevOps infrastructure.
 
 Here are some specific examples:
 

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -71,7 +71,7 @@ The most important consideration is to form the team in a way that allows the or
 
 Due to their central role, core team members should nearly always fill the role of [Trusted Committers][tc] as well.
 While the [Trusted Committer][tc] role focuses mostly on facilitating others' contribution and use of the project, a core team member regularly contributes to the project as well.
-The core team doesn't have its own business agenda that determines its contibutions.
+The core team doesn't have its own business agenda that determines its contributions.
 They decide what to contribute based on what will help others most to use and contribute to the project.
 
 A good way to continually remind the core team of this goal is to have them report regularly on:

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -66,7 +66,7 @@ Here are some specific examples:
 Each of these items is very important to a healthy product ecosystem, yet is unlikely to be prioritized as a contribution.
 
 The core team may be composed of a small number of people on a full-time or a part-time basis.
-The choice depends on the amount of work needed, the availibility of resources, and the culture of the organization.
+The choice depends on the amount of work needed, the availability of resources, and the culture of the organization.
 The most important consideration is to form the team in a way that allows the organization to empower and hold them accountable in the same way as any other team.
 
 Due to their central role, core team members should nearly always fill the role of [Trusted Committers][tc] as well.

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -4,7 +4,7 @@ Core Team
 
 ## Patlet
 
-Even when an InnerSource project is widely needed, contributions and usage may be stymied because the project is difficult to work with.
+Even when an InnerSource project is widely needed, contributions and usage may be hindered because the project is difficult to work with.
 Establish a core team that is dedicated to take care of the project's fundamental items.
 Their work enables contributors to add and use the features that provide value to their scenarios.
 
@@ -35,7 +35,7 @@ It's clearly due for an overhaul (e.g. refactoring, testing, documentation, etc.
 * Many teams need the project.
 * The project has significant tech debt.
 * Slow adoption and iteration on the project.
-* Nobody is taking reponsibility for the project and contribution ecosystem as a whole.
+* There is not a owner or maintainer who takes reponsibility for the project and contribution ecosystem as a whole.
 
 ## Forces
 
@@ -52,16 +52,16 @@ Categories of this type of work include communication, local environment, and De
 
 Here are some specific examples:
 
-* Production bugs.
-* Documentation.
-* Onboarding tutorials and examples.
-* Automated testing.
-* CI/CD.
-* Local environment.
-* Modularization.
-* Versioning.
-* Monitoring.
-* Trailblazing new classes/categories of features.
+* Production bugs
+* Documentation
+* Onboarding tutorials and examples
+* Automated testing
+* CI/CD
+* Local environment
+* Modularization
+* Versioning
+* Monitoring
+* Trailblazing new classes/categories of features
 
 Each of these items is very important to a healthy product ecosystem, yet is unlikely to be prioritized as a contribution.
 
@@ -72,7 +72,7 @@ The most important consideration is to form the team in a way that allows the or
 Due to their central role, core team members should nearly always fill the role of [Trusted Committers][tc] as well.
 While the [Trusted Committer][tc] role focuses mostly on facilitating others' contribution and use of the project, a core team member regularly contributes to the project as well.
 The core team doesn't have its own business agenda that determines its contributions.
-They decide what to contribute based on what will help others most to use and contribute to the project.
+They decide what to work on based on what will help others most to use and contribute to the project.
 
 A good way to continually remind the core team of this goal is to have them report regularly on:
 

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -69,10 +69,10 @@ The core team may be composed of a small number of people on a full-time or a pa
 The choice depends on the amount of work needed, the availibility of resources, and the culture of the organization.
 The most important consideration is to form the team in a way that allows the organization to empower and hold them accountable in the same way as any other team.
 
-Due to their central role, core team members should nearly always fill the role of [Trusted Committers] as well.
-While the [Trusted Committer] role focuses mostly on facilitating others' contribution and use of the project, a core team member regularly contributes to the project as well.
+Due to their central role, core team members should nearly always fill the role of [Trusted Committers][tc] as well.
+While the [Trusted Committer][tc] role focuses mostly on facilitating others' contribution and use of the project, a core team member regularly contributes to the project as well.
 The core team doesn't have its own business agenda that determines its contibutions.
-They decide what to contribute based on what will most help others to use and contribute to the project.
+They decide what to contribute based on what will help others most to use and contribute to the project.
 
 A good way to continually remind the core team of this goal is to have them report regularly on:
 
@@ -104,5 +104,4 @@ Structured
 
 [Russell R. Rutledge](https://github.com/rrrutledge)
 
-[Trusted Committers]: https://innersourcecommons.org/learn/learning-path/trusted-committer/
-[Trusted Committer]: https://innersourcecommons.org/learn/learning-path/trusted-committer/
+[tc]: https://innersourcecommons.org/learn/learning-path/trusted-committer/

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -5,7 +5,7 @@ Core Team
 ## Patlet
 
 Is your InnerSource project difficult for people to work with, yet no one is interested in improving it?
-Establish a core team to take care of those fundamental items so that contributors can focus on adding features that provide value to them.
+Establish a core team to take care of the project's fundamental items so that contributors are enabled to add and use the features that provide value to their scenarios.
 
 ## Problem
 
@@ -14,7 +14,7 @@ This could be due to things like:
   * Can't run the project locally.
   * Poor documentation.
   * Convoluted code.
-  * Lack of adequate testing.
+  * Inadequate testing.
 * It is difficult to use the project.
 Some possible causes:
   * Poor documentation (again).
@@ -25,29 +25,30 @@ Some possible causes:
 
 There's a central project that everyone depends on.
 What a great candidate for InnerSource!
-Unfortunately, the project has grown organically, with various contributions and additions just slapped on.
+Unfortunately, the project has grown organically, with various contributions and additions slapped on haphazardly.
 Now it's an icky, black morass of code that no one understands and everyone is afraid to touch.
-It's clearly due for an overhaul, but even though everyone needs it and wants it, no one takes the time to work on it.
+It's clearly due for an overhaul, but even though everyone needs that and wants it, no one takes the time to work on it.
 
 ## Context
 
-* Project is full of tech debt.
 * Many teams use the project.
-* Tech debt slows adoption and iteration on the project.
+* Significant tech debt.
+* Slow adoption and iteration on the project.
 
 ## Forces
 
 * Everyone is busy.
 * Each contributing team prioritizes work that results in an immediate payoff for that team.
-* As the project grows the natural trend is for the project to become more difficult to use and to modify.
+* As the project grows the natural trend is for it to become more difficult to use and to modify.
 
 ## Solution
 
-Form a core team whose job it is to maintain the project in a state so that others can easily onboard to it and contribute to it.
-This core team does the work that is necessary for a healthy usage and contribution ecosystem yet tends to be work that is not prioritized as a contribution.
-Some main catogories of this type of work include communication, local environment, and devops infrastructure.
+Form a core team whose job it is to maintain the project in a state so that others can easily onboard and contribute to it.
+This core team does the work that is necessary for a healthy usage and contribution ecosystem.
+This critical work tends to not be prioritized as a contribution.
+Catogories of this type of work include communication, local environment, and devops infrastructure.
 Here are some specific examples:
-* Production bugs
+* Production bugs.
 * Documentation.
 * Onboarding tutorials and examples.
 * Automated testing.
@@ -58,15 +59,17 @@ Here are some specific examples:
 * Monitoring.
 * Trailblazing new classes/categories of features.
 
-Each of these items is very important to a healthy product ecosystem, yet is unlikely to be prioritized regularly as a contribution.
+Each of these items is very important to a healthy product ecosystem, yet is unlikely to be prioritized as a contribution.
 
-Due to their central role, core team members should nearly always be [Trusted Committers](https://patterns.innersourcecommons.org/p/trusted-committer) as well.
-While the [Trusted Committer] focuses mostly on facilitating others' contribution and use of the project, a core team member regularly contributes to the project as well.
+Due to their central role, core team members should nearly always fill the role of [Trusted Committers] as well.
+While the [Trusted Committer] role focuses mostly on facilitating others' contribution and use of the project, a core team member regularly contributes to the project as well.
 The core team doesn't have its own business agenda that determines its contibutions.
 They decide what to contribute based on what will most help others to use and contribute to the project.
 
-A good way to continually remind the core team of this goal is to have them report regularly on the number of active teams using the project and the number of off-team contributions to the project.
-Continual focus on these metrics and effort to help them improve will naturally drive the core team to prioritize generally the right work to create a thriving InnerSource ecosystem around their project.
+A good way to continually remind the core team of this goal is to have them report regularly on
+* number of active teams using the project
+* number of off-team contributions to the project.
+Continual focus on these metrics will naturally drive the core team to prioritize generally the right work to create a thriving InnerSource ecosystem around the project.
 
 ## Resulting Context
 
@@ -77,7 +80,7 @@ Continual focus on these metrics and effort to help them improve will naturally 
 ## Rationale
 
 Separating out a core team and tasking them in this way helps to fill the gaps that a successful project needs yet are left behind by contributors that are pursuing their own agenda only.
-The core team fills the gaps and greases the wheels so that the contribution ecosystem remains healthy.
+The core team fills those gaps and greases the wheels so that the contribution ecosystem remains healthy.
 
 ## Known Instances
 
@@ -87,4 +90,5 @@ Nike implented this pattern to manage the InnerSource effort around its reusable
 
 [Russell R. Rutledge](https://github.com/rrrutledge)
 
-[Trusted Committers]: https://patterns.innersourcecommons.org/p/trusted-committer
+[Trusted Committers]: https://innersourcecommons.org/learn/learning-path/trusted-committer/
+[Trusted Committer]: https://innersourcecommons.org/learn/learning-path/trusted-committer/

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -47,7 +47,9 @@ Form a core team whose job it is to maintain the project in a state so that othe
 This core team does the work that is necessary for a healthy usage and contribution ecosystem.
 This critical work tends to not be prioritized as a contribution.
 Catogories of this type of work include communication, local environment, and devops infrastructure.
+
 Here are some specific examples:
+
 * Production bugs.
 * Documentation.
 * Onboarding tutorials and examples.

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -28,7 +28,7 @@ There's a central project that everyone depends on.
 What a great candidate for InnerSource!
 Unfortunately, the project has grown organically, with various contributions and additions slapped on haphazardly.
 Now it's an icky, thick morass of code that no one understands and everyone is afraid to touch.
-It's clearly due for an overhaul (e.g. refactoring, testing, documentation, etc.), but even though everyone needs and wants that work, no one takes the time to do it.
+It's clearly due for an overhaul (e.g. refactoring, testing, documentation, etc.), but even though everyone needs and wants that work to happen, no one takes the time to do it.
 
 ## Context
 


### PR DESCRIPTION
Is your InnerSource project difficult for people to work with, yet no one is interested in improving it? Establish a core team to take care of the project's fundamental items so that contributors are enabled to add and use the features that provide value to their scenarios.

- - -

View the [rendered markdown](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/pattern/core-team/patterns/2-structured/core-team.md).