### PR TITLE
Add Flutter example to Service vs. Library

### DIFF
--- a/patterns/2-structured/service-vs-library.md
+++ b/patterns/2-structured/service-vs-library.md
@@ -83,9 +83,8 @@ Related to this pattern is the [30 Day Warranty](30-day-warranty.md) pattern tha
 
 ## Known Instances
 
-Europace AG
-
-Flutter Entertainment: typical InnerSource application has a shared code "service" repository with cross-team contribution and CI pipeline to build and publish a shared release artefact. Each adopting team has a "deployment config" repository defining their own deployment. This is driven by varying regulatory requirements, service and incident management practices and infrastructure skillsets in different areas of the business.
+* Europace AG
+* Flutter Entertainment: A typical InnerSource application has a shared code "service" repository with cross-team contribution and CI pipeline to build and publish a shared release artefact. Each adopting team has a "deployment config" repository defining their own deployment. This is driven by varying regulatory requirements, service and incident management practices and infrastructure skillsets in different areas of the business.
 
 ## Status
 
@@ -93,8 +92,8 @@ Flutter Entertainment: typical InnerSource application has a shared code "servic
 
 ## Author(s)
 
-Isabel Drost-Fromm
-Rob Tuley
+* Isabel Drost-Fromm
+* Rob Tuley
 
 ## Acknowledgements
 

--- a/patterns/2-structured/service-vs-library.md
+++ b/patterns/2-structured/service-vs-library.md
@@ -49,8 +49,7 @@ Teams may have different security or regulatory constraints governing their depl
 Decouple responsibility for source code from deployment: Both teams work to
 identify exactly where there is overlap and synergies.
 
-Only shared source code is kept as part of the InnerSource project with shared
-responsibility. Test and release packaging should be included in the shared source to allow shared change validation.
+Only shared source code is kept as part of the InnerSource project with shared responsibility. The shared source should be coherent in that it includes all testing code (including integration tests if available) and as much of the CI pipeline as is possible to make contribution validation easier. 
 
 Decouple configuration and deployment pipelines from actual business logic.
 Establish a second deployment of the service for the second team.
@@ -58,7 +57,7 @@ Establish a second deployment of the service for the second team.
 Treat the common base as a library that is used by both teams with shared code
 ownership.
 
-Deployment configurations can be included as separate projects in your InnerSource portfolio to allow teams to discuss/collaborate or a new team to copy.
+Deployment configurations can be included as separate projects in your InnerSource portfolio to allow teams to discuss/collaborate or a new team to copy them.
 
 ## Resulting Context
 

--- a/patterns/2-structured/service-vs-library.md
+++ b/patterns/2-structured/service-vs-library.md
@@ -74,7 +74,7 @@ The likelihood that changes are needed and made in the shared source code
 increases, leading to more frequent opportunities to refine, improve and optimise
 the implementation.
 
-Encourages incremental operational standardisation in release packaging, telemetry, health/readiness endpoints in the shared code.
+Encourages incremental operational standardisation in release packaging, telemetry, health/readiness endpoints and so on as the teams realise they can more efficiently maintain this in the shared code if they agree on standard conventions.
 
 ## See also
 

--- a/patterns/2-structured/service-vs-library.md
+++ b/patterns/2-structured/service-vs-library.md
@@ -83,7 +83,7 @@ Related to this pattern is the [30 Day Warranty](30-day-warranty.md) pattern tha
 ## Known Instances
 
 * Europace AG
-* Flutter Entertainment: A [Flutter InnerSource application](https://innersource.flutter.com/start/setup-ci/) has a shared code "service" repository with cross-team contribution and CI pipeline to build and publish a shared release artefact. Each adopting team has a "deployment config" repository defining their own deployment. This is driven by varying regulatory requirements, service and incident management practices and infrastructure skillsets in different areas of the business. 
+* Flutter Entertainment: A [Flutter InnerSource application](https://innersource.flutter.com/start/setup-ci/) has a shared code "service" repository with cross-team contribution and CI pipeline to build and publish a shared release artefact. Each adopting team has a "deployment config" repository defining their own deployment. This is driven by varying regulatory requirements, service and incident management practices and infrastructure skillsets in different areas of the business.
 
 ## Status
 

--- a/patterns/2-structured/service-vs-library.md
+++ b/patterns/2-structured/service-vs-library.md
@@ -83,7 +83,7 @@ Related to this pattern is the [30 Day Warranty](30-day-warranty.md) pattern tha
 ## Known Instances
 
 * Europace AG
-* Flutter Entertainment: A typical InnerSource application has a shared code "service" repository with cross-team contribution and CI pipeline to build and publish a shared release artefact. Each adopting team has a "deployment config" repository defining their own deployment. This is driven by varying regulatory requirements, service and incident management practices and infrastructure skillsets in different areas of the business.
+* Flutter Entertainment: A [Flutter InnerSource application](https://innersource.flutter.com/start/setup-ci/) has a shared code "service" repository with cross-team contribution and CI pipeline to build and publish a shared release artefact. Each adopting team has a "deployment config" repository defining their own deployment. This is driven by varying regulatory requirements, service and incident management practices and infrastructure skillsets in different areas of the business. 
 
 ## Status
 

--- a/patterns/2-structured/service-vs-library.md
+++ b/patterns/2-structured/service-vs-library.md
@@ -49,7 +49,7 @@ Teams may have different security or regulatory constraints governing their depl
 Decouple responsibility for source code from deployment: Both teams work to
 identify exactly where there is overlap and synergies.
 
-Only shared source code is kept as part of the InnerSource project with shared responsibility. The shared source should be coherent in that it includes all testing code (including integration tests if available) and as much of the CI pipeline as is possible to make contribution validation easier. 
+Only shared source code is kept as part of the InnerSource project with shared responsibility. The shared source should be coherent in that it includes all testing code (including integration tests if available) and as much of the CI pipeline as is possible to make contribution validation easier.
 
 Decouple configuration and deployment pipelines from actual business logic.
 Establish a second deployment of the service for the second team.

--- a/patterns/2-structured/service-vs-library.md
+++ b/patterns/2-structured/service-vs-library.md
@@ -42,19 +42,23 @@ do not affect their own downstream customers.
 Severity levels for the same types of errors may be different across team
 boundaries due to different SLA definitions per team/customer relationship.
 
+Teams may have different security or regulatory constraints governing their deployments.
+
 ## Solutions
 
 Decouple responsibility for source code from deployment: Both teams work to
 identify exactly where there is overlap and synergies.
 
 Only shared source code is kept as part of the InnerSource project with shared
-responsibility.
+responsibility. Test and release packaging should be included in the shared source to allow shared change validation.
 
 Decouple configuration and deployment pipelines from actual business logic.
 Establish a second deployment of the service for the second team.
 
 Treat the common base as a library that is used by both teams with shared code
 ownership.
+
+Deployment configurations can be included as separate projects in your InnerSource portfolio to allow teams to discuss/collaborate or a new team to copy.
 
 ## Resulting Context
 
@@ -71,6 +75,8 @@ The likelihood that changes are needed and made in the shared source code
 increases, leading to more frequent opportunities to refine, improve and optimise
 the implementation.
 
+Encourages incremental operational standardisation in release packaging, telemetry, health/readiness endpoints in the shared code.
+
 ## See also
 
 Related to this pattern is the [30 Day Warranty](30-day-warranty.md) pattern that takes a different approach to solving the forces described above.
@@ -79,6 +85,8 @@ Related to this pattern is the [30 Day Warranty](30-day-warranty.md) pattern tha
 
 Europace AG
 
+Flutter Entertainment: typical InnerSource application has a shared code "service" repository with cross-team contribution and CI pipeline to build and publish a shared release artefact. Each adopting team has a "deployment config" repository defining their own deployment. This is driven by varying regulatory requirements, service and incident management practices and infrastructure skillsets in different areas of the business.
+
 ## Status
 
 * Structured
@@ -86,6 +94,7 @@ Europace AG
 ## Author(s)
 
 Isabel Drost-Fromm
+Rob Tuley
 
 ## Acknowledgements
 


### PR DESCRIPTION
Added Flutter Entertainment experience to the Service vs. Library pattern as this is an approach we use a lot. Our main learning point in this space is to ensure the "shared code" is coherent in that it also includes all testing code (incl integration tests if available) and keep as much of the CI pipeline shared as is possible.

Questions:

- I wasn't sure whether external links from examples are desirable or not: [there is further detail here](https://innersource.flutter.com/start/setup-ci/) on how we would typically divide CI pipeline steps between shared vs not-shared (plus some of the challenges this approach still has for us) but wasn't sure whether to include it.
- I'm unclear on bulleting conventions -- I wanted to convert various sections of discrete sentence points to be bulleted which I've seen in other patterns but wasn't sure whether to do so, or convert tone into paragraph type linked text instead. 