### PR TITLE
Renaming the keys for the 'Support and Maintenance' group

### DIFF
--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -175,10 +175,10 @@ InnerSource projects need a means for self assessment. Metrics can be one aspect
 
 Not only should feature development be owned by InnerSource teams - support and maintenance is also part of the teams core tasks.
 
-* SP-0: Support given by the core dev or support team. A business contract guaranties the support. There is no knowledge about the product outside the team.
-* SP-1: There are rules and regulations to formalize the support on the product, given by a dedicated supporting team.
-* SP-2: Support for InnerSource contributions is formalized through InnerSource patterns like [30 Day Warranty](./30-day-warranty.md) or [Service vs. Library](./service-vs-library.md).
-* SP-3: There are rules and regulations to formalize the support on the product, given by a mature community.
+* SM-0: Support given by the core dev or support team. A business contract guaranties the support. There is no knowledge about the product outside the team.
+* SM-1: There are rules and regulations to formalize the support on the product, given by a dedicated supporting team.
+* SM-2: Support for InnerSource contributions is formalized through InnerSource patterns like [30 Day Warranty](./30-day-warranty.md) or [Service vs. Library](./service-vs-library.md).
+* SM-3: There are rules and regulations to formalize the support on the product, given by a mature community.
 
 **Culture**
 


### PR DESCRIPTION
I was reading the Maturity Model, and noticed that the keys of two groups were colliding with each other.
Both groups **Sharing Policies** and **Support and Maintenance** were using keys prefixed with `SP-`.

I am assuming here that the keys are supposed to be unique within the file. If that is not the case, please disregard this PR :)

Changes made in this PR:
* renamed keys for the **Support and Maintenance** group to `SM-` stead.

Command used to extra only the rows with the rules/keys from the file (mostly a mental note for myself):
`ack "\* .{2}\-\d" maturity-model.md | sort`

