### PR TITLE
Adding Isabel Drost-Fromm as author to Initial patterns

### DIFF
--- a/patterns/1-initial/explicit-innersource-principles.md
+++ b/patterns/1-initial/explicit-innersource-principles.md
@@ -162,3 +162,7 @@ projects.
 ## Status
 
 Initial
+
+## Authors
+
+* Isabel Drost-Fromm

--- a/patterns/1-initial/explicit-shared-ownership.md
+++ b/patterns/1-initial/explicit-shared-ownership.md
@@ -50,3 +50,7 @@ There is a proven way to adjust the setup in the future.
 # Status
 
 Initial (early draft)
+
+## Authors
+
+* Isabel Drost-Fromm

--- a/patterns/1-initial/governance-levels.md
+++ b/patterns/1-initial/governance-levels.md
@@ -70,3 +70,7 @@ TBD
 ## Status
 
 Initial (Early draft)
+
+## Authors
+
+* Isabel Drost-Fromm


### PR DESCRIPTION
Adding @MaineC as authors to these 3 Initial patterns.
The goal of this is to allow further contributors to clarify questions with the initial author, as we improve the pattern further (e.g. leveling it up to Structured)

I confirmed with @MaineC that this change is fine, so will merge it as is without further review.