### PR TITLE
Switching to markdown syntax of pictures in all Structured Patterns

### DIFF
--- a/patterns/2-structured/30-day-warranty.md
+++ b/patterns/2-structured/30-day-warranty.md
@@ -36,7 +36,7 @@ Note that the warranty period could be 45, 60, or 100 days too. The duration may
 
 In addition it helps to provide clear [contribution guidelines](./project-setup/base-documentation.md), spelling out the expectations of the receiving team and the contributing team.
 
-<img alt="30 Day Warranty" src="/assets/img/thirtydaywarranty.jpg" width="70%">
+![30 Day Warranty](../../assets/img/thirtydaywarranty.jpg)
 
 ## Resulting Context
 

--- a/patterns/2-structured/common-requirements.md
+++ b/patterns/2-structured/common-requirements.md
@@ -35,7 +35,7 @@ Additionally, take advantage of customers expecting the supplier to help elucida
 
 In the example presented above, the supplier helps both customers realize that they want the same thing, and it will save everyone effort (and money) if they agree to accept the result in the same format.
 
-<img alt="Common Requirements" src="/assets/img/CommonReqtsv2.jpg">
+![Common Requirements](../../assets/img/CommonReqtsv2.jpg)
 
 ## Resulting Context
 

--- a/patterns/2-structured/contracted-contributor.md
+++ b/patterns/2-structured/contracted-contributor.md
@@ -64,7 +64,7 @@ time.
 - The governance office offers to mediate between the contributor and her line manager in case of conflict regarding the time for contributions.
 - The [Dedicated Community Leader](dedicated-community-leader.md) participates in or provides input for performance reviews of contributors contracted for more than 20 %.
 
-<img alt="Contracted Contributor" src="/assets/img/contracted-contributor.png" width="70%">
+![Contracted Contributor](../../assets/img/contracted-contributor.png)
 
 ## Resulting Context
 

--- a/patterns/2-structured/review-committee.md
+++ b/patterns/2-structured/review-committee.md
@@ -31,7 +31,7 @@ Company A wants to introduce its first InnerSource initiative. Most managers in 
 - An InnerSource project leader can also present the motion to be shut down on its own initiative on a review committee. The review committee then has to decide whether or not the business units using the software need to be given time to put measures in place to ensure that development and/or maintenance of the codebase continues until an alternative solution to development by the InnerSource community is found (if business relevant or mission critical).
 - The review committee should convene regularly. A cadence of two meetings per year has proven successful.
 
-<img alt="Review Committee Sketch" src="/assets/img/review-committee-sketch.jpg" width="70%">
+![Review Committee Sketch](../../assets/img/review-committee-sketch.jpg)
 
 ## Resulting Context
 


### PR DESCRIPTION
Switching to markdown syntax of pictures in all Structured Patterns, as otherwise the alias doesn't get displayed correctly as a caption below the picture in gitbook.