### PR TITLE
Embed in book mindmap using markdown syntax

### DIFF
--- a/book/explore-patterns.md
+++ b/book/explore-patterns.md
@@ -6,7 +6,7 @@ Now how to make it easy for readers to discover the patterns that can help them 
 
 For this purpose we provide this mind map. It **categorizes patterns based on the different phases of an InnerSource Program**, and the challenges that might appear in the respective phases.
 
-<img src="../pattern-categorization/innersource-program-mind-map.png" title="InnerSource Patterns as a Mind Map">
+![Mind Map of InnerSource Patterns](../pattern-categorization/innersource-program-mind-map.png)
 
 ## Improve this Mind Map
 

--- a/book/toc_template.md
+++ b/book/toc_template.md
@@ -14,7 +14,7 @@ Instead edit toc_template.md
 * [Explore Patterns](../book/explore-patterns.md)
 * [Contribute to this book](../book/contribute.md)
 
-<img src="../pattern-categorization/innersource-program-mind-map.png" title="InnerSource Patterns as a Mind Map">
+![Mind Map of InnerSource Patterns](../pattern-categorization/innersource-program-mind-map.png)
 
 ## Patterns <a id="p"></a>
 


### PR DESCRIPTION
Just like in #380 now using markdown syntax rather than HTML syntax to embed the mindmap in the book.
That should enlarge the mindmap as well, making it easier to read.