### PR TITLE
Fix the capitalization for the 'Introduction' page in the book

### DIFF
--- a/book/toc_template.md
+++ b/book/toc_template.md
@@ -10,6 +10,7 @@ Instead edit toc_template.md
 
 # Table of Contents
 
+* [Introduction](../book/introduction.md)
 * [Table of Contents](../book/toc.md)
 * [Explore Patterns](../book/explore-patterns.md)
 * [Contribute to this book](../book/contribute.md)


### PR DESCRIPTION
Trying to fix the capitalization for the 'Introduction' page in the [book](https://patterns.innersourcecommons.org/). 

_What happened?_
Since the latest gitbook relesae this has been shown in lowercase, rather than uppercase.

<img width="341" alt="Screenshot 2022-01-08 at 17 49 13 " src="https://user-images.githubusercontent.com/163029/148652865-a83f61c8-7ada-4854-935e-21d990663b0c.png">

