### PR TITLE
Fix duplicate header on ToC page

### DIFF
--- a/book/toc_template.md
+++ b/book/toc_template.md
@@ -1,14 +1,14 @@
+# Table of Contents
+
 <!--
 Do not edit toc.md directly!!!
 Instead edit toc_template.md
 -->
 
 <!--
-  GOTCHA !!!
+  NOTE:
   Paths in here are relative to this file, and not relative to the root specified in .gitbook.yaml.
 -->
-
-# Table of Contents
 
 * [Introduction](../book/introduction.md)
 * [Table of Contents](../book/toc.md)


### PR DESCRIPTION
The table of contents (ToC) page in the book shows the same header twice.

This is only happening to the ToC but not for other default files that gitbook uses (like `introduction.md`).
I am moving the headline in the ToC file to the very top, to see if it gets handled correct by git book then (i.e. I expect to only see the title "Table of Contents" once).

Current (buggy) behavior:

<img width="586" alt="Screenshot 2022-01-08 at 19 18 25 " src="https://user-images.githubusercontent.com/163029/148655266-148c02c7-06dc-4f3a-98bb-079086dc64d8.png">



