### PR TITLE
Adding Rob Tuley as our latest Trusted Committer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @lenucksi @NewMexicoKid @cewilliams @spier
+*       @lenucksi @NewMexicoKid @cewilliams @spier @robtuley
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only

--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -10,6 +10,7 @@ For further information about the concept, also see the [Trusted Committer Patte
 
 ## Current Trusted Committers
 
+* [@robtuley](https://github.com/robtuley) (added 2022-02-15)
 * [@spier](https://github.com/spier) (added 2020-12-11)
 * [@lenucksi](https://github.com/lenucksi) (added 2020-04-24)
 * [@NewMexicoKid](https://github.com/NewMexicoKid) (added 2017-03-02)


### PR DESCRIPTION
Onboarding new Trusted Committer based on [these instructions](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/main/TRUSTED-COMMITTERS.md#process-for-adding-new-trusted-committers).

In this PR:

- [x] New TC is added to this file (`TRUSTED-COMMITTERS.md`) 
- [x] New TC is added to `.github/CODEOWNERS`, so that they get notified about new PRs automatically

Other things to do manually:

- [x] New TC receives write access to this repository
- [x] New TC is added to the [#innersource-patterns](https://app.slack.com/client/T04PXKRM0/C2EFRTS6A)-tcs channel
- [x] New TC is praised in the #innersource-patterns channel.