### PR TITLE
Recommendations for using InnerSource as a verb in a sentence

### DIFF
--- a/meta/innersource-spelling.md
+++ b/meta/innersource-spelling.md
@@ -10,7 +10,7 @@ We encourage you to use the word as a proper noun (like “We published the repo
 
 We favor the spelling **InnerSource**, for the following reasons:
 
-1. That’s the way Tim O’Reilly [spelled it in 2000][opengl_1200] (he was into Perl and Pascal case was a thing). Also see the [Foreword of the Adopting InnerSource book][foreword_AdoptingInnerSource] for more of Tim O’Reilly's own words on the topic.
+1. That’s the way Tim O’Reilly [spelled it in 2000][opengl_1200] (he was into Perl and camel-case was a thing). Also see the [Foreword of the Adopting InnerSource book][foreword_AdoptingInnerSource] for more of Tim O’Reilly's own words on the topic.
 2. If you set up side-by-side Google searches for “Inner Source” and “InnerSource” you will find that you get more hits on the former term, by only 1% of them have anything to do with what we call InnerSource. The latter term will be 100% cogent to your inquiry.
 3. The OSI was [denied trademark on the term “open source”][no-open-source-trademark] because it was made up of two common and unrelated terms. “InnerSource” on the other hand is a new word.
 
@@ -24,7 +24,7 @@ For new patterns we stick to the spelling **InnerSource**. Old patterns will be 
 
 ## It can be hard to use the term "InnerSource" in a sentence
 
-Some people have had a hard time with the Pascal case term **InnerSource** because they’re not sure how to use it in a sentence grammatically.
+Some people have had a hard time with the camel-case term **InnerSource** because they’re not sure how to use it in a sentence grammatically.
 
 We recommend not to turn the term into a verb, but rather using it as a noun or adjective.
 

--- a/meta/innersource-spelling.md
+++ b/meta/innersource-spelling.md
@@ -10,7 +10,7 @@ We encourage you to use the word as a proper noun (like “We published the repo
 
 We favor the spelling **InnerSource**, for the following reasons:
 
-1. That’s the way Tim O’Reilly [spelled it in 2000][opengl_1200] (he was into Perl and camel-case was a thing). Also see the [Foreword of the Adopting InnerSource book][foreword_AdoptingInnerSource] for more of Tim O’Reilly's own words on the topic.
+1. That’s the way Tim O’Reilly [spelled it in 2000][opengl_1200] (he was into Perl and Pascal case was a thing). Also see the [Foreword of the Adopting InnerSource book][foreword_AdoptingInnerSource] for more of Tim O’Reilly's own words on the topic.
 2. If you set up side-by-side Google searches for “Inner Source” and “InnerSource” you will find that you get more hits on the former term, by only 1% of them have anything to do with what we call InnerSource. The latter term will be 100% cogent to your inquiry.
 3. The OSI was [denied trademark on the term “open source”][no-open-source-trademark] because it was made up of two common and unrelated terms. “InnerSource” on the other hand is a new word.
 
@@ -24,7 +24,7 @@ For new patterns we stick to the spelling **InnerSource**. Old patterns will be 
 
 ## It can be hard to use the term "InnerSource" in a sentence
 
-Some people have had a hard time with the camel-case term **InnerSource** because they’re not sure how to use it in a sentence grammatically.
+Some people have had a hard time with the Pascal case term **InnerSource** because they’re not sure how to use it in a sentence grammatically.
 
 We recommend not to turn the term into a verb, but rather using it as a noun or adjective.
 

--- a/meta/innersource-spelling.md
+++ b/meta/innersource-spelling.md
@@ -30,13 +30,14 @@ We recommend not to turn the term into a verb, but rather using it as a noun or 
 
 Recommended use:
 
-“We published the repository as InnerSource.”
-or
-“We published the repository under an InnerSource license.”
+- “We use InnerSource in that repo.”
+- “We use InnerSource methods in that repo.”
+- “We published the repository as InnerSource.”
+- “We published the repository under an InnerSource license.”
 
 Not so good:
 
-“We’re InnerSourcing that repo”
+- “We’re InnerSourcing that repo.”
 
 [opengl_1200]: https://web.archive.org/web/20180411080939/http://archive.oreilly.com/pub/a/oreilly/ask_tim/2000/opengl_1200.html
 [foreword_AdoptingInnerSource]: https://innersourcecommons.org/assets/files/AdoptingInnerSource.pdf

--- a/meta/innersource-spelling.md
+++ b/meta/innersource-spelling.md
@@ -32,6 +32,7 @@ Recommended use:
 
 > “We use InnerSource in that repo.”<br/>
 “We use InnerSource methods in that repo.”<br/>
+“We follow InnerSource development methods in that repo.”<br/>
 “We published the repository as InnerSource.”
 
 Not so good:

--- a/meta/innersource-spelling.md
+++ b/meta/innersource-spelling.md
@@ -2,7 +2,7 @@
 
 We recommend the spelling **InnerSource**.
 
-We encourage you to use the word as a proper noun (like “We published the repository as InnerSource”) wherever possible. We discourage the use of verb forms of the word (like “We’re InnerSourcing that repo”).
+We encourage you to use the word as a proper noun (like “We use InnerSource in that repo.”) wherever possible. We discourage the use of verb forms of the word (like “We’re InnerSourcing that repo”).
 
 ## Full story - Why we care about the spelling
 
@@ -30,14 +30,13 @@ We recommend not to turn the term into a verb, but rather using it as a noun or 
 
 Recommended use:
 
-- “We use InnerSource in that repo.”
-- “We use InnerSource methods in that repo.”
-- “We published the repository as InnerSource.”
-- “We published the repository under an InnerSource license.”
+> “We use InnerSource in that repo.”<br/>
+“We use InnerSource methods in that repo.”<br/>
+“We published the repository as InnerSource.”
 
 Not so good:
 
-- “We’re InnerSourcing that repo.”
+> “We’re InnerSourcing that repo.”
 
 [opengl_1200]: https://web.archive.org/web/20180411080939/http://archive.oreilly.com/pub/a/oreilly/ask_tim/2000/opengl_1200.html
 [foreword_AdoptingInnerSource]: https://innersourcecommons.org/assets/files/AdoptingInnerSource.pdf

--- a/meta/innersource-spelling.md
+++ b/meta/innersource-spelling.md
@@ -2,7 +2,7 @@
 
 We recommend the spelling **InnerSource**.
 
-We encourage you to use the word as a proper noun (like “We use InnerSource in that repo”) wherever possible. We discourage the use of verb forms of the word (like “We’re inner-sourcing that repo”).
+We encourage you to use the word as a proper noun (like “We published the repository as InnerSource”) wherever possible. We discourage the use of verb forms of the word (like “We’re InnerSourcing that repo”).
 
 ## Full story - Why we care about the spelling
 
@@ -30,9 +30,9 @@ We recommend not to turn the term into a verb, but rather using it as a noun or 
 
 Recommended use:
 
-“We use InnerSource in that repo”
+“We published the repository as InnerSource.”
 or
-“We use InnerSource methods in that repo”
+“We published the repository under an InnerSource license.”
 
 Not so good:
 


### PR DESCRIPTION
The proposed changes are based on the following Slack thread: https://innersourcecommons.slack.com/archives/C04PXKRN4/p1649258602339809

The changes include:
- example sentences when InnerSource is used as a verb
- proposed correction of camel-case to 'Pascal case' as it is a more frequently used term than 'upper camel case'



**Note:**
In the long term it would be nice to spell InnerSource more like open source and maybe allow using it as a verb too (just because it rolls off the tongue).