### PR TITLE
RFC Pattern - Adding Know Instance from DAZN

### DIFF
--- a/patterns/2-structured/transparent-cross-team-decision-making-using-rfcs.md
+++ b/patterns/2-structured/transparent-cross-team-decision-making-using-rfcs.md
@@ -97,7 +97,7 @@ Also for decision making outside of pure software design decisions, transparent 
 - **Europace** - As described in Open Organization: [Setting cross-team standards and best practices in the open][europace].
 - **Uber** - According to this blog post by Gergely Orosz: [Scaling Engineering Teams via RFCs: Writing Things Down][uber].
 - **Google Design Docs** - As described in this blog post by Malte Ubl [Design Docs at Google][google]
-- **DAZN** - One way that DAZN makes technical decisions is via RFCs. RFCs are used for decisions that apply to engineering-wide processes only! The RFCs live in a GitHub repository, and technical standards are then gradually adopted within our tools and by our engineers in the company. An RFC can be raised by any engineer, and voted on by all engineers. If upvotes exceed downvotes, the RFC is adopted. It’s worth noting, that the RFC voting process hasn’t yet been “stress-tested” by any contentious decisions. - As described in this blog post by Lou Bichard: [Building A DX Team: Lessons Learned][dazn]
+- **DAZN** - One way that DAZN makes technical decisions is via RFCs. RFCs are used for decisions that apply to engineering-wide processes only! The RFCs live in a GitHub repository, and technical standards are then gradually adopted within their tools and by their engineers. An RFC can be raised by any engineer, and voted on by all engineers. If upvotes exceed downvotes, the RFC is adopted. It’s worth noting, that the RFC voting process hasn’t yet been “stress-tested” by any contentious decisions. - As described in this blog post by Lou Bichard: [Building A DX Team: Lessons Learned][dazn]
 
 ## Status
 

--- a/patterns/2-structured/transparent-cross-team-decision-making-using-rfcs.md
+++ b/patterns/2-structured/transparent-cross-team-decision-making-using-rfcs.md
@@ -97,7 +97,7 @@ Also for decision making outside of pure software design decisions, transparent 
 - **Europace** - As described in Open Organization: [Setting cross-team standards and best practices in the open][europace].
 - **Uber** - According to this blog post by Gergely Orosz: [Scaling Engineering Teams via RFCs: Writing Things Down][uber].
 - **Google Design Docs** - As described in this blog post by Malte Ubl [Design Docs at Google][google]
-- **DAZN** - One way that DAZN makes technical decisions is via RFCs. RFCs are used for decisions that apply to engineering-wide processes only! The RFCs live in a GitHub repository, and technical standards are then gradually adopted within their tools and by their engineers. An RFC can be raised by any engineer, and voted on by all engineers. If upvotes exceed downvotes, the RFC is adopted. It’s worth noting, that the RFC voting process hasn’t yet been “stress-tested” by any contentious decisions. - As described in this blog post by Lou Bichard: [Building A DX Team: Lessons Learned][dazn]
+- **DAZN** (10/2021) - One way that DAZN makes technical decisions is via RFCs. RFCs are used for decisions that apply to engineering-wide processes only! The RFCs live in a GitHub repository, and technical standards are then gradually adopted within their tools and by their engineers. An RFC can be raised by any engineer, and voted on by all engineers. If upvotes exceed downvotes, the RFC is adopted. It’s worth noting, that the RFC voting process hasn’t yet been “stress-tested” by any contentious decisions. - As described in this blog post by Lou Bichard: [Building A DX Team: Lessons Learned][dazn]
 
 ## Status
 

--- a/patterns/2-structured/transparent-cross-team-decision-making-using-rfcs.md
+++ b/patterns/2-structured/transparent-cross-team-decision-making-using-rfcs.md
@@ -97,6 +97,7 @@ Also for decision making outside of pure software design decisions, transparent 
 - **Europace** - As described in Open Organization: [Setting cross-team standards and best practices in the open][europace].
 - **Uber** - According to this blog post by Gergely Orosz: [Scaling Engineering Teams via RFCs: Writing Things Down][uber].
 - **Google Design Docs** - As described in this blog post by Malte Ubl [Design Docs at Google][google]
+- **DAZN** - One way that DAZN makes technical decisions is via RFCs. RFCs are used for decisions that apply to engineering-wide processes only! The RFCs live in a GitHub repository, and technical standards are then gradually adopted within our tools and by our engineers in the company. An RFC can be raised by any engineer, and voted on by all engineers. If upvotes exceed downvotes, the RFC is adopted. It’s worth noting, that the RFC voting process hasn’t yet been “stress-tested” by any contentious decisions. - As described in this blog post by Lou Bichard: [Building A DX Team: Lessons Learned][dazn]
 
 ## Status
 
@@ -121,3 +122,4 @@ Structured
 [open-decision-framework]: https://www.redhat.com/en/about/press-releases/red-hat-releases-open-decision-framework-spur-transparent-and-inclusive-leadership
 [bbc]: https://www.youtube.com/watch?v=U6zlghE0HcE
 [google]: https://www.industrialempathy.com/posts/design-docs-at-google/
+[dazn]: https://medium.com/dazn-tech/building-a-dx-team-lessons-learned-4a66446088bc


### PR DESCRIPTION
This [blog post ](https://medium.com/dazn-tech/building-a-dx-team-lessons-learned-4a66446088bc) by DAZN already contains more info about their RFC process than what we normally need for an org to be added as a Known Instance to a pattern.

This PR contains a summary of what the blog post shares about their RFC usage.

I am also informing DAZN about this PR, to see if they want to add anything else about their use of RFCs.

Part of #392 