### PR TITLE
Introduce lychee link checker (instead of liche)

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,7 +1,7 @@
 # from: https://github.com/lycheeverse/lychee-action
 # link checker used is 'lychee': https://github.com/lycheeverse/lychee
 
-name: Link Check on Patterns and README
+name: Link Check
 
 on:
   push:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,5 +1,5 @@
-# from: https://github.com/marketplace/actions/link-checker
-# link checker used is 'liche': https://github.com/raviqqe/liche
+# from: https://github.com/lycheeverse/lychee-action
+# link checker used is 'lychee': https://github.com/lycheeverse/lychee
 
 name: Link Check on Patterns and README
 
@@ -16,14 +16,6 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-    # - uses: actions/checkout@v2
-    # - name: Link Checker
-    #   id: lc
-    #   uses: peter-evans/link-checker@v1
-    #   with:
-    #     args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com|https://github.com/rcs/rcs-viewer/pull/81|fearlesschangepatterns.com|https://ulir.ul.ie/bitstream/handle/10344/4443/Stol_2014_inner.pdf|https://docs.github.com/en/rest/metrics/statistics|https://docs.github.com/en/rest/search#search-repositories" README.md patterns/ book/ translation/ -r
-    # - name: Fail if there were link errors
-    #   run: exit ${{ steps.lc.outputs.exit_code }}
       - uses: actions/checkout@v3
 
       - name: Restore lychee cache

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -30,5 +30,6 @@ jobs:
         with:
           args: --verbose --no-progress --cache --max-cache-age 1d README.md patterns/ book/ translation/
           fail: true
+          jobSummary: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -24,8 +24,6 @@ jobs:
     #     args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com|https://github.com/rcs/rcs-viewer/pull/81|fearlesschangepatterns.com|https://ulir.ul.ie/bitstream/handle/10344/4443/Stol_2014_inner.pdf|https://docs.github.com/en/rest/metrics/statistics|https://docs.github.com/en/rest/search#search-repositories" README.md patterns/ book/ translation/ -r
     # - name: Fail if there were link errors
     #   run: exit ${{ steps.lc.outputs.exit_code }}
-
-    steps:
       - uses: actions/checkout@v3
 
       - name: Link Checker

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -26,10 +26,17 @@ jobs:
     #   run: exit ${{ steps.lc.outputs.exit_code }}
       - uses: actions/checkout@v3
 
+      - name: Restore lychee cache
+        uses: actions/cache@v3
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.5.0
         with:
-          args: --verbose --no-progress README.md patterns/ book/ translation/
+          args: --verbose --no-progress --cache --max-cache-age 1d README.md patterns/ book/ translation/
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -16,11 +16,22 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Link Checker
-      id: lc
-      uses: peter-evans/link-checker@v1
-      with:
-        args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com|https://github.com/rcs/rcs-viewer/pull/81|fearlesschangepatterns.com|https://ulir.ul.ie/bitstream/handle/10344/4443/Stol_2014_inner.pdf|https://docs.github.com/en/rest/metrics/statistics|https://docs.github.com/en/rest/search#search-repositories" README.md patterns/ book/ translation/ -r
-    - name: Fail if there were link errors
-      run: exit ${{ steps.lc.outputs.exit_code }}
+    # - uses: actions/checkout@v2
+    # - name: Link Checker
+    #   id: lc
+    #   uses: peter-evans/link-checker@v1
+    #   with:
+    #     args: -v -d . -x "http://creativecommons.org/licenses|https://isc-inviter.herokuapp.com|https://github.com/rcs/rcs-viewer/pull/81|fearlesschangepatterns.com|https://ulir.ul.ie/bitstream/handle/10344/4443/Stol_2014_inner.pdf|https://docs.github.com/en/rest/metrics/statistics|https://docs.github.com/en/rest/search#search-repositories" README.md patterns/ book/ translation/ -r
+    # - name: Fail if there were link errors
+    #   run: exit ${{ steps.lc.outputs.exit_code }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.5.0
+        with:
+          args: --verbose --no-progress README.md patterns/ book/ translation/
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,3 +2,7 @@
 # The file allows you to list multiple regular expressions for exclusion (one pattern per line).
 https://example.com/link/to/your/trusted/committer/documentation.md
 https://github.com/rcs/rcs-viewer/pull/81
+http://creativecommons.org/licenses
+https://isc-inviter.herokuapp.com
+fearlesschangepatterns.com
+https://ulir.ul.ie/bitstream/handle/10344/4443/Stol_2014_inner.pdf

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+# These links are ignored by our link checker https://github.com/lycheeverse/lychee
+# The file allows you to list multiple regular expressions for exclusion (one pattern per line).
+https://example.com/link/to/your/trusted/committer/documentation.md
+https://github.com/rcs/rcs-viewer/pull/81

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,3 +6,4 @@ http://creativecommons.org/licenses
 https://isc-inviter.herokuapp.com
 fearlesschangepatterns.com
 https://ulir.ul.ie/bitstream/handle/10344/4443/Stol_2014_inner.pdf
+.*@andrew.clegg.*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Check Links](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/link-checker.yml/badge.svg)](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/link-checker.yml)
+
 # InnerSource Patterns
 
 <a href="https://patterns.innersourcecommons.org">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Check Links](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/link-checker.yml/badge.svg)](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/link-checker.yml)
+[![Pattern Syntax Validation](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/lint-patterns.yml/badge.svg)](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/lint-patterns.yml)
 
 # InnerSource Patterns
 


### PR DESCRIPTION
The previously used link checker [liche](https://github.com/raviqqe/liche) has been deprecated.
Recommended alternative is [lychee](https://github.com/lycheeverse/lychee).

I hope that with this we can also fix the failing link checks due to rate limiting on checks of GitHub links.