### PR TITLE
Setting URL for the Appendix section explicitly for the JP book

### DIFF
--- a/book/jp/toc_template.md
+++ b/book/jp/toc_template.md
@@ -21,7 +21,7 @@ Instead edit toc_template.md
 
 <<PATTERS_HERE>>
 
-## 付録
+## 付録<a id="appendix"></a>
 
 * [パターンテンプレート](../../meta/pattern-template.md)
 * その他


### PR DESCRIPTION
After doing an investigate in #435 it turned out that trying to make all URLs in the JP book the exact same as in the EN book might be possible but would introduce a maintenance issue for us going forward.

Therefore I am opting for a lot simpler change, that can be done with a tiny code change.

_Note:_
After this PR the URLs for README template and CONTRIBUTING template will still be different in the JP book!