### PR TITLE
Add image visualizing the four governance levels

### DIFF
--- a/patterns/1-initial/governance-levels.md
+++ b/patterns/1-initial/governance-levels.md
@@ -58,6 +58,9 @@ Examples of building blocks:
   on the project direction. Everyone has an equal say in who else to add to this
   group.
 
+![image](https://user-images.githubusercontent.com/70953/197144534-42dafb93-9d2d-46d1-a1f2-e7a70e593f6c.png)
+
+
 ## Resulting Context
 
 Teams can adopt InnerSource best practices in a step-by-step way. By documenting

--- a/patterns/1-initial/governance-levels.md
+++ b/patterns/1-initial/governance-levels.md
@@ -60,7 +60,6 @@ Examples of building blocks:
 
 ![image](https://user-images.githubusercontent.com/70953/197144534-42dafb93-9d2d-46d1-a1f2-e7a70e593f6c.png)
 
-
 ## Resulting Context
 
 Teams can adopt InnerSource best practices in a step-by-step way. By documenting


### PR DESCRIPTION
I'm sure we can find a better visualization from someone who can create images in the InnerSource Commons look and feel. What I want the image to communicate:

* Each level adds more karma to the contributing team.
* The last level though needs a switch in thinking - for the last level what is created in a way is a project on neutral ground where both teams can collaborate each in enlightened self interest. Typically though not all (contributing/host-)team members will be equally active in that project.

What I think would make sense to also capture in the visual but failed to capture myself: Each step requires more transparency and shared communication resources between both teams.

For full disclosure: Feel free to dump this pull request in favor of a different picture with the correct look and feel.