### PR TITLE
Fix GHA deprecation warning (upgrade lychee-action to 1.5.2)

### DIFF
--- a/.github/workflows/link-checker-prs.yml
+++ b/.github/workflows/link-checker-prs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - if: ${{ env.MARKDOWN_FILES != '' }}
         name: Link Checker
-        uses: lycheeverse/lychee-action@v1.5.1
+        uses: lycheeverse/lychee-action@v1.5.2
         with:
           args: --verbose --no-progress --cache --max-cache-age 1d $MARKDOWN_FILES
           fail: true

--- a/.github/workflows/link-checker-prs.yml
+++ b/.github/workflows/link-checker-prs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - if: ${{ env.MARKDOWN_FILES != '' }}
         name: Link Checker
-        uses: lycheeverse/lychee-action@v1.5.0
+        uses: lycheeverse/lychee-action@v1.5.1
         with:
           args: --verbose --no-progress --cache --max-cache-age 1d $MARKDOWN_FILES
           fail: true

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: cache-lychee-
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.5.1
+        uses: lycheeverse/lychee-action@v1.5.2
         with:
           args: --verbose --no-progress --cache --max-cache-age 1d README.md patterns/ book/ translation/
           fail: true

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -24,7 +24,7 @@ jobs:
           restore-keys: cache-lychee-
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.5.0
+        uses: lycheeverse/lychee-action@v1.5.1
         with:
           args: --verbose --no-progress --cache --max-cache-age 1d README.md patterns/ book/ translation/
           fail: true

--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ NOTE: The 'Initial' Patterns below don't have a Patlet yet, which is essential f
 This is why we keep these patterns at the bottom of the list.
 -->
 
-change something
-
 * [Overcome Acquisition Based Silos - Developers](patterns/1-initial/overcome-acquisition-based-silos-developer.md)
 * [Overcome Acquisition Based Silos - Managers](patterns/1-initial/overcome-acquisition-based-silos-manager.md)
 * [Discover Your InnerSource](patterns/1-initial/discover-your-innersource.md)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ NOTE: The 'Initial' Patterns below don't have a Patlet yet, which is essential f
 This is why we keep these patterns at the bottom of the list.
 -->
 
+change something
+
 * [Overcome Acquisition Based Silos - Developers](patterns/1-initial/overcome-acquisition-based-silos-developer.md)
 * [Overcome Acquisition Based Silos - Managers](patterns/1-initial/overcome-acquisition-based-silos-manager.md)
 * [Discover Your InnerSource](patterns/1-initial/discover-your-innersource.md)


### PR DESCRIPTION
Got a deprecation warning in this [link checker action run](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/runs/3344043721).

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/