### PR TITLE
Add more links to Slack + Introduce template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Slack
+    url: https://innersourcecommons-inviter.herokuapp.com
+    about: Join our Community on Slack for help and a casual chat.
+  - name: Patterns Book
+    url: https://patterns.innersourcecommons.org
+    about: Read our most mature patterns here.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Check Links](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/link-checker.yml/badge.svg)](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/link-checker.yml)
 [![Pattern Syntax Validation](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/lint-patterns.yml/badge.svg)](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/workflows/lint-patterns.yml)
+[![Join our Slack!](https://img.shields.io/static/v1?message=join%20chat&color=9cf&logo=slack&label=slack)](https://innersourcecommons-inviter.herokuapp.com)
 
 # InnerSource Patterns
 


### PR DESCRIPTION
Let's make it easier for visitors of our patterns repo to find our slack.

To do so I did this:
- Add links to slack + book when creating an issue. 
- Add link to Slack at the top of the main README.

As part of this I also created the base for the [template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) that GitHub offers.

We don't have templates yet but I am consider to add some templates e.g. for
- creating a quick draft of a new pattern
- submitting a Known Instance of a new pattern

Btw I got inspired to do this work when seeing the [template chooser in the mermaid-js repo](https://github.com/mermaid-js/mermaid/issues/new/choose).


