### PR TITLE
Adding WellSky as a Known Instance to the Core Team pattern

### DIFF
--- a/patterns/1-initial/incubator-pipeline.md
+++ b/patterns/1-initial/incubator-pipeline.md
@@ -14,7 +14,7 @@ The team managing the shared code library needs a way to allow InnerSource contr
 
 ## Story
 
-See [Culture, Behaviors, and InnerSource. A three-part blog series. 3 of 3](https://www.linkedin.com/pulse/culture-behaviors-innersource-three-part-blog-series-3-gil-yehuda/) for the conceptual inspiration for this pattern. 
+See [Culture, Behaviors, and InnerSource. A three-part blog series. 3 of 3](https://www.linkedin.com/pulse/culture-behaviors-innersource-three-part-blog-series-3-gil-yehuda/) for the conceptual inspiration for this pattern.
 
 _Note: This may be replaced with a direct story from the dev team who implemented this pattern. Watch this space._
 
@@ -86,4 +86,3 @@ Initial
 * John Sibo
 * Jennifer Skov
 * John Yopp
-

--- a/patterns/2-structured/core-team.md
+++ b/patterns/2-structured/core-team.md
@@ -95,7 +95,8 @@ The core team fills those gaps and greases the wheels so that the contribution e
 
 ## Known Instances
 
-Nike implemented this pattern to manage the InnerSource effort around its reusable CI/CD pipelines.
+* **Nike** implemented this pattern to manage the InnerSource effort around its reusable CI/CD pipelines.
+* **WellSky** established a Core Team for a key project. This allowed them to scale their InnerSource contributions to that project significantly - see [Wide-Scaled InnerSource with a Core Team](https://www.youtube.com/watch?v=kgxexjYdhIc).
 
 ## Status
 


### PR DESCRIPTION
@rrrutledge your [presentation](https://www.youtube.com/watch?v=kgxexjYdhIc) is from 2021 but I only realize now that through that we can also add WellSky as a Known Instance to the Core Team pattern, can't we?

I wrote a little blurb that I extracted from your video but feel free to replace it entirely, if it doesn't make sense.

Also if you have any online reference for how this pattern was used at Nike, we could add that as well. 