### PR TITLE
Governance Levels Name & Level

### DIFF
--- a/patterns/1-initial/governance-levels.md
+++ b/patterns/1-initial/governance-levels.md
@@ -1,6 +1,6 @@
 ## Title
 
-Transparent Governance Levels
+Common Language
 
 ## Patlet
 


### PR DESCRIPTION
The governance levels pattern I think was previously agreed to move to structured status. This is a PR to do that, and also to double check the name. 

**Naming**

I get where "Transparent Governance Levels" is coming from but it doesn't resonant with me personally. I think it focuses the reader's attention on governance processes rather that the root problem of ambiguous language use between people/teams. For me it becomes easier to govern InnerSource practices however you wish if you have a Common Language to more precisely describe it. But I do see that if you have Transparent Governance Levels in place then that should and will form a common language.

So I would propose changing the name of the pattern to "Common Language". 

**Move to Structured**

I'm not sure how to do this? At a guess...

- move the md file to the `patterns/2-structured` dir. Rename to new name if one is agreed otherwise stick with same name.
- update README
- something for the ja version? 
- ...?