### PR TITLE
Deduplicate entry for 'Time Constraints Hamper Inner Source Progress'

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ This is why we keep these patterns at the bottom of the list.
 #### Donuts (needing a solution)
 
 * [How to Defeat the Hierarchical Constraints](patterns/1-initial/defeat-hierarchical-constraints.md)
-* [Project Management Time Pressures](patterns/1-initial/overcoming-project-management-time-pressures.md)
 * [Organizational Mindset Change](patterns/1-initial/organizational-mindset-change.md)
 * [Bad Weather For Liftoff](patterns/1-initial/bad-weather-for-liftoff.md)
 * [Incentive mechanisms to foster voluntary contribution](patterns/1-initial/incentive-mechanisms-for-voluntary-contribution.md)

--- a/patterns/1-initial/overcoming-project-management-time-pressures.md
+++ b/patterns/1-initial/overcoming-project-management-time-pressures.md
@@ -57,3 +57,7 @@ TBD
 ## Status
 
 Initial
+
+## Alias
+
+Overcoming Project Management Time Pressures

--- a/patterns/1-initial/overcoming-project-management-time-pressures.md
+++ b/patterns/1-initial/overcoming-project-management-time-pressures.md
@@ -4,7 +4,7 @@ Time Constraints Hamper InnerSource Progress
 
 ## Patlet
 
-TBD
+Project management believes timeline pressure and commitments on feature content does not allow for developers to spend the time needed to develop shareable code and provide support.
 
 ## Problem
 


### PR DESCRIPTION
Noticed that we got this pattern listed twice in our main README.
This PR does a minimal change to fix this.

- Adding alias
- Adding in Patlet that we used in the README. Not a true patlet but rather a modification of the Problem section.
- Remove duplicate entry in README
