### PR TITLE
Generalize the maturity model pattern

### DIFF
--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -30,13 +30,9 @@ InnerSource project differs depending on each team.
 
 ## Forces
 
-Teams sharing InnerSource learnings run into misunderstandings as they are not
-aware of their respective level of InnerSource adoption.
-
-Teams believe that "it's all about migrating to a shared software development
-[forge](https://en.wikipedia.org/wiki/Forge_%28software%29)" (GitLab, GitHub, or Bitbucket being well known examples of such forges).
-
-Teams are not aware of best practices that would help them solve issues that
+* Teams sharing InnerSource learnings run into misunderstandings as they are not aware of their respective level of InnerSource adoption.
+* Teams believe that "it's all about migrating to a shared software development [forge](https://en.wikipedia.org/wiki/Forge_%28software%29)" (GitLab, GitHub, or Bitbucket being well known examples of such forges).
+* Teams are not aware of best practices that would help them solve issues that
 they run into in their daily doing.
 
 ## Solution

--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -208,13 +208,9 @@ InnerSource comes with explicit roles. While in early stages some patterns may b
 
 ## Resulting Context
 
-All teams are aware of available best practices.
-
-Teams understand their level of InnerSource adoption.
-
-Prior to adopting InnerSource as a working model, teams are aware of the
-practices that are expected of them - both in the short term and in the
-long term.
+* All teams are aware of available best practices.
+* Teams understand their level of InnerSource adoption.
+* Prior to adopting InnerSource as a working model, teams are aware of the practices that are expected of them - both in the short term and in the long term.
 
 ## Known Instances
 

--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -31,8 +31,7 @@ pain points that they are dealing with.
 
 * Teams sharing InnerSource learnings run into misunderstandings as they are not aware of their respective level of InnerSource adoption.
 * Teams believe that "it's all about migrating to a shared software development [forge](https://en.wikipedia.org/wiki/Forge_%28software%29)" (GitLab, GitHub, or Bitbucket being well known examples of such forges).
-* Teams are not aware of best practices that would help them solve issues that
-they run into in their daily doing.
+* Teams are not aware of best practices that would help them solve issues that they run into in their daily doing.
 
 ## Solution
 

--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -32,7 +32,24 @@ pain points that they are dealing with.
 
 ## Solution
 
-Ask teams to self assess against the proposed maturity model.
+For this pattern in particular it is important to note that adopters of this pattern will likely not use the maturity modal proposed here as is!
+The context of most organization will differ to greatly to do that.
+Hence you may take the proposed maturity model as a starting point if you like, but it is key that you adapt it to the needs and goals of your orgnization!
+
+Steps to implement:
+
+1. **maturity mode definition**: Create a maturity model that fits the needs of your organization. Also consider the [Guiding Principles](../2-structured/document-your-guiding-principles.md) if you have defined those for your InnerSource program.
+2. **team self-assessment**: Then ask teams to self-assess against that maturity model. You may even do a couple of these sessions together with a view teams, to observe and learn if the maturity model is easy enough to understand.
+3. ... <what happens now? e.g. any re-assessments after some time, or suggested actions after the assessment, or anything else?>
+
+Note that the path is part of the goal in multiple ways here:
+
+* Defining your own maturity model allows you, the organizers of the InnerSource program, to increase your own clarity. e.g. you will realize what matters to you, what training capabilities you have internally, what material is available externally, etc
+* You increase the trust in your initiative by allowing teams to go through the self-assessment at their own pace, and by opening up to feedback from them.
+* The teams going through the self-assessment will likely have discussions, possibly even disagreements about some of the points in the Maturity Model. That is fantastic as it offers a great starting point for relevant discussions to increase their shared understanding of InnerSource.
+
+Below we have defined a sample maturity model around 4 categories (Transparency, Collaboration, Community, Governance).
+Make sure you adapt this model to fit your organization!
 
 ### Transparency
 

--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -22,11 +22,10 @@ pain points that they are dealing with.
 
 ## Context
 
-Several teams have started adopting InnerSource practices. The exact level of
-understanding of the practice diverges between teams. The exact problems teams
-run into diverge depending on the context and working environment of each team.
-As a result the definition of what are important best practices in an
-InnerSource project differs depending on each team.
+* Several teams have started adopting InnerSource practices.
+* The exact level of understanding of the practice diverges between teams.
+* The exact problems teams run into diverge depending on the context and working environment of each team.
+* As a result the definition of what are important best practices in an InnerSource project differs depending on each team.
 
 ## Forces
 

--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -5,7 +5,7 @@ Maturity Model
 ## Patlet
 
 The InnerSource practices are spreading to multiple teams and departments, however the understanding of what constitutes an InnerSource project varies.
-Defining a maturity model enablesq teams to do a self-assessment and discover patterns and practices that they are not yet aware of.
+Defining a maturity model enables teams to do a self-assessment and discover patterns and practices that they are not yet aware of.
 
 ## Problem
 

--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -228,6 +228,7 @@ long term.
 * Isabel Drost-Fromm
 * Jorge
 * Nerea
+* Sebastian Spier
 
 ## Acknowledgements
 

--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -4,11 +4,8 @@ Maturity Model
 
 ## Patlet
 
-Teams have started adopting InnerSource. The practice is spreading to multiple
-departments. However, the understanding of what constitutes an InnerSource
-project varies. The solution is to provide a maturity model to allow for teams
-to go through a self check and discover patterns and practices that they are not
-yet aware of.
+The InnerSource practices are spreading to multiple teams and departments, however the understanding of what constitutes an InnerSource project varies.
+Defining a maturity model enablesq teams to do a self-assessment and discover patterns and practices that they are not yet aware of.
 
 ## Problem
 


### PR DESCRIPTION
By generalizing the marity model pattern we hope to allow for other orgs to list themselves as adopters of this pattern, even if they may be using a maturity model that is different from the one proposed in this pattern.

At the same time we think that providing a maturity model as part of this pattern has its merits, as it allows readers to understand in greater depth what this goals of this pattern are.

## Key changes

- rewrite Patlet into the 2 sentence form (1 problem + 1 solution)
- Generalize the Solution section. Separate the definition of the maturity model from the self-assessment of the teams.
- Formatting Forces, Context, and Resulting Context as list, to allow for easier checking
