### PR TITLE
Removing link to innersourceportal.santander.com

### DIFF
--- a/translation/ja/patterns/innersource-portal.md
+++ b/translation/ja/patterns/innersource-portal.md
@@ -75,7 +75,7 @@
 
 * **アメリカン航空**は、[インターナルインナーソースマーケットプレイス](https://tech.aa.com/2020-10-30-innersource/)を介してInnerSourceプロジェクトを推進しています。SAPと同様に、プロジェクトはGitHubのトピックとして `innersource` を追加することで自己登録されます。プロジェクトは、言語、トピック、オープンイシューの数などで検索やフィルタリングが可能です。
 
-* **Banco Santander**社は、インナーソースをサポートして増やすために、[Santander ONE Europe InnerSource Community](https://innersourceportal.santander.com/)という公開ポータルを作成しました。このポータルには、プロジェクトのカタログに加え、ドキュメント、仕事の進め方、ニュース、イベントなどの関連コンテンツが含まれています。
+* **Banco Santander**社は、インナーソースをサポートして増やすために、Santander ONE Europe InnerSource Communityという公開ポータルを作成しました。このポータルには、プロジェクトのカタログに加え、ドキュメント、仕事の進め方、ニュース、イベントなどの関連コンテンツが含まれています。
 
 ![Santander InnerSource Portal](../../../assets/img/santander_portal.png "Banco Santander InnerSource Portal")
 


### PR DESCRIPTION
Our automatic link check was [failing](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/runs/4956839678/jobs/8867775461) due to a broken link to innersourceportal.santander.com.

@yuhattor could you confirm if the formatting of the text in Japanese is still ok, after removing the link?



