### PR TITLE
Add GitHub to release-process as a known instance

### DIFF
--- a/patterns/2-structured/release-process.md
+++ b/patterns/2-structured/release-process.md
@@ -58,6 +58,7 @@ Release notes are also a great opportunity to [praise participants](praise-parti
 ## Known Instances
 
 * Comcast (multiple projects)
+* GitHub (multiple projects)
 
 ## Authors
 


### PR DESCRIPTION
GitHub also uses this release project on several innersource projects. I figure adding to the known instances list builds trust in the pattern so thought I would add to it.