### PR TITLE
Porting board report for this WG here

### DIFF
--- a/meta/boardreports/2023-08.md
+++ b/meta/boardreports/2023-08.md
@@ -1,0 +1,53 @@
+# InnerSource Patterns WG - Report for Board Meeting 2023-08
+
+## Meta
+
+* Reporting Period: 2023-05..2023-07
+* [merged PRs](https://github.com/InnerSourceCommons/InnerSourcePatterns/pulls?q=is%3Apr+closed%3A2023-05..2023-07+is%3Amerged)
+* [opened issues](https://github.com/InnerSourceCommons/InnerSourcePatterns/issues?q=is%3Aissue+created%3A2023-05..2023-07+is%3Aopen)
+
+## Engagement
+
+The [patterns book][] is the way InnerSource practices are captured and shared. Recent web analytics:
+
+* stable traffic on the patterns book (tracking_id: `G-QL1S8MW5D9`)
+  * 19,704 views total (previous report was 18,361 page)
+  * Last month we had 50% more traffic, but traffic did not drop and we were able to slightly exceed that again this time!
+  * Last month was not stable, with high traffic at the beginning of April. This month, traffic was stable overall.
+* Most popular patterns:
+  * InnerSource Portal
+  * 30 Day Warranty
+  * Core Team
+  * Standard Base Documentation
+  * Common Requirements
+* traffic for translations:
+  * Japanese - 1,596 views total (somewhat continuous traffic but with spikes of 291 page views when @yuhattor introduced InnerSource Patterns at the Platform Engineering Meetup on 5/15/2023.
+  * Chinese - 15 views total
+
+## Changes
+
+Changes are contributed via the [InnerSourcePatterns][] repository:
+
+* Known Instances (applications of our patterns in the wild)
+  * Adding Mercedes-Benz to **Innersource Portal** - thank you @wgehring
+  * Adding WellSky to **Service vs. Library** - thank you @rrrutledge
+* Creating `COMMUNICATION-template.md` to streamline the communication. The [final goal](https://github.com/InnerSourceCommons/InnerSourcePatterns/issues/535) is to add this to the **Standard Base Documentation** pattern. - thank you @kschueths
+* Updating Airbus implementation of the **Innersource Portal** pattern. Backstage Case Studies have been added. - thank you @sicot-f
+* **Extensions for Sustainable Growth** has been translated by @yuhattor and merged into main. Not in production yet - thank you @bakisunsan for the review.
+* Script for pattern maintainers, to find upgradeable patterns based on their number of Known Instances - thank you @spier
+* Adding a Spelling & Style checker (using vale). Also used by the Learning Path already. For further details about the approach with vale also see [isc-styles](https://github.com/InnerSourceCommons/isc-styles) - thank you @spier
+* Interesting new development (in July/August)
+  * pattern proposal [Feature Owner](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/573) by Manoj Gawande (@magawande) from Fidelty (part of FINOS?) - new contributor!
+  * proposal to add a [Code of Conduct template](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/556) to the **Standard Base Documentation** pattern - by Jose Roman Martin Gil (@rmarting) from Red Hat - new contributor?
+  * some folks got to together to translate the patterns to Brazilian Portuguese. Still [in progress](https://github.com/jrcosta/InnerSourcePatterns/tree/book-ptbr/translation/pt) but so cool!
+
+* Last [Trusted Committer][] added was [@yuhattor](https://github.com/yuhattor) (added 2022-07-21)
+* Trusted Committer candidates in the pipeline: No
+
+## Next Goals
+
+Same as previous Board report.
+
+[patterns book]: https://patterns.innersourcecommons.org/
+[InnerSourcePatterns]: https://github.com/InnerSourceCommons/InnerSourcePatterns/
+[Trusted Committer]: https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/main/TRUSTED-COMMITTERS.md


### PR DESCRIPTION
These reports are created for the Board of InnerSource Commons. They are maintained in a private repo.
However to create transparency for any contributors to this Patterns Working Group, we also keep a copy of these reports in our repo here:
https://github.com/InnerSourceCommons/InnerSourcePatterns/tree/main/meta/boardreports
