### PR TITLE
Render RFC templates in book

### DIFF
--- a/book/en/toc.md
+++ b/book/en/toc.md
@@ -50,6 +50,7 @@ Instead edit toc_template.md
 * Extras
   * [README Template](../../patterns/2-structured/project-setup/templates/README-template.md)
   * [CONTRIBUTING Template](../../patterns/2-structured/project-setup/templates/CONTRIBUTING-template.md)
+  * [RFC Template](../../patterns/2-structured/templates/rfc.md)
 
 ## Resources
 

--- a/book/en/toc_template.md
+++ b/book/en/toc_template.md
@@ -27,6 +27,7 @@ Instead edit toc_template.md
 * Extras
   * [README Template](../../patterns/2-structured/project-setup/templates/README-template.md)
   * [CONTRIBUTING Template](../../patterns/2-structured/project-setup/templates/CONTRIBUTING-template.md)
+  * [RFC Template](../../patterns/2-structured/templates/rfc.md)
 
 ## Resources
 

--- a/book/zh/toc.md
+++ b/book/zh/toc.md
@@ -47,6 +47,7 @@ Instead edit toc_template.md
 * 额外
   * [README 模板](../../translation/zh/templates/README-template.md)
   * [CONTRIBUTING 模板](../../translation/zh/templates/CONTRIBUTING-template.md)
+  * [RFC 模板](../../translation/zh/templates/rfc.md)  
 
 ## 资源
 

--- a/book/zh/toc_template.md
+++ b/book/zh/toc_template.md
@@ -27,6 +27,7 @@ Instead edit toc_template.md
 * 额外
   * [README 模板](../../translation/zh/templates/README-template.md)
   * [CONTRIBUTING 模板](../../translation/zh/templates/CONTRIBUTING-template.md)
+  * [RFC 模板](../../translation/zh/templates/rfc.md)  
 
 ## 资源
 


### PR DESCRIPTION
We already have the README and CONTRIBUTING template embedded directly in our gitbook.
However for some reason we did not do that for the RFC template (referenced in https://patterns.innersourcecommons.org/p/transparent-cross-team-decision-making-using-rfcs).

Changes:
- Adding en RFC template to menu of the book. That way it renders in gitbook, rather than redirecting to github.
- Adding zh translation of RFC template to the book
