### PR TITLE
Improved Trusted Committer documentation

### DIFF
--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -17,6 +17,15 @@ For further information about the concept, also see the [Trusted Committer Patte
 * [@NewMexicoKid](https://github.com/NewMexicoKid) (added 2017-03-02)
 * [@cewilliams](https://github.com/cewilliams) (added 2017-03-02)
 
+### Translation Leads
+
+In addition to the Trusted Committers, these Translation Leads help us with the translation of our patterns to other languages.
+While they don't take all responsibilities of a Trusted Committer (yet), they do have increased permissions so that they can work with our patterns more easily.
+
+* Japanese - [@yuhattor](https://github.com/yuhattor)
+* Chinese - [@WillemJiang](https://github.com/WillemJiang)
+* Brazilian Portuguese - [@jrcosta](https://github.com/jrcosta), [@zilio](https://github.com/zilio)
+
 ## Hall of Fame (aka Alumni)
 
 While Trusted Committers are in principle appointed for lifetime, interests or priorities of a TC can change and they might not have enough time any more to contribute to the project.

--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -21,7 +21,7 @@ For further information about the concept, also see the [Trusted Committer Patte
 
 While Trusted Committers are in principle appointed for lifetime, interests or priorities of a TC can change and they might not have enough time any more to contribute to the project.
 
-In those cases we ask them if we should move them to the Hall of Fame. Doing so allows us to appropriately thank them for all of their fantastic contributions. When doing so we also remove them from `.github/CODEOWNERS`, so that reviews of Pull Requests aren't assigned to them anymore, and GitHub notifications are reduced. That increases the clarity for the community who to expect feedback from when creating PRs.
+In those cases we ask them if we should move them to the Hall of Fame. Doing so allows us to appropriately thank them for all of their fantastic contributions. When doing so we also remove them from [.github/CODEOWNERS](.github/CODEOWNERS), so that reviews of Pull Requests aren't assigned to them anymore, and GitHub notifications are reduced. That increases the clarity for the community who to expect feedback from when creating PRs.
 
 The alumni in the Hall of Fame can of course always start contributing again in the future and go back to being Trusted Committers if they want to.
 
@@ -44,8 +44,8 @@ We follow this process:
 4. The TC who nominated the candidate informs her/him in private about the nomination and its acceptance. The candidate can decide on whether to accept or reject the offer.
 5. If the candidate accepts the offer, the TC who nominated the candidate, makes sure:
    1. New TC receives write access to this repository (this needs to happen first, so that step 5.iii works)
-   2. New TC is added to this file (`TRUSTED-COMMITTERS.md`)
-   3. New TC is added to `.github/CODEOWNERS`, so that they get notified about new PRs automatically
+   2. New TC is added to this file [TRUSTED-COMMITTERS.md](./TRUSTED-COMMITTERS.md)
+   3. New TC is added to [.github/CODEOWNERS](.github/CODEOWNERS), so that they get notified about new PRs automatically
    4. New TC is added to the `#innersource-patterns-tcs` channel
    5. New TC is praised in the [#innersource-patterns](https://app.slack.com/client/T04PXKRM0/C2EFRTS6A) channel.
 

--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -46,13 +46,13 @@ We follow this process:
 1. Any Trusted Committer (TC) can nominate a new TC in the private Slack channel `#innersource-patterns-tcs`. The TC should provide the following information:
    * Name of the candidate
    * Reason for candidate
-   * Github handle of the candidate
+   * GitHub handle of the candidate
    * Slack handle of the candidate
 2. Every TC can raise concerns or second the nomination in the #innersource-patterns-tcs channel.
 3. If none of the existing TCs disagrees with the nomination within 72h, [lazy consensus](https://tech.europace.de/lazy-consensus-vs-explicit-voting/) is reached: The nomination is accepted.
 4. The TC who nominated the candidate informs her/him in private about the nomination and its acceptance. The candidate can decide on whether to accept or reject the offer.
 5. If the candidate accepts the offer, the TC who nominated the candidate, makes sure:
-   1. New TC receives write access to this repository (this needs to happen first, so that step 5.iii works)
+   1. New TC receives `WRITE` access to this repository (this needs to happen first, so that step 5.iii works)
    2. New TC is added to this file [TRUSTED-COMMITTERS.md](./TRUSTED-COMMITTERS.md)
    3. New TC is added to [.github/CODEOWNERS](.github/CODEOWNERS), so that they get notified about new PRs automatically
    4. New TC is added to the `#innersource-patterns-tcs` channel

--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -43,7 +43,7 @@ We work based on trust: Our goal is to add most people who contributed a sizeabl
 
 We follow this process:
 
-1. Any trusted committer (TC) can nominate a new TC in the private Slack channel `#innersource-patterns-tcs`. The TC should provide the following information:
+1. Any Trusted Committer (TC) can nominate a new TC in the private Slack channel `#innersource-patterns-tcs`. The TC should provide the following information:
    * Name of the candidate
    * Reason for candidate
    * Github handle of the candidate
@@ -62,8 +62,8 @@ We follow this process:
 
 A handful of individuals are currently the technical GitHub Admins for this repository. This includes most members of the InnerSource Commons' #tech-infra team and members of the [InnerSource Commons GitHub Organization](https://github.com/innersourcecommons).
 
-However, please channel working group-specific requests through the trusted committers.
+However, please channel working group-specific requests through the Trusted Committers.
 
 ## References
 
-Our trusted committer process was inspired by [this](https://tech.europace.de/voting-in-new-trusted-committers/).
+Our Trusted Committer process was inspired by [this](https://tech.europace.de/voting-in-new-trusted-committers/).


### PR DESCRIPTION
While working on a cleanup of our repo permissions (in #594), I noticed that the documentation about our Trusted Committer process was missing some bits.

This PR addresses those.