### PR TITLE
[GHA issue metrics] Make the codeowners uniq

### DIFF
--- a/.github/workflows/pattern-metrics.yaml
+++ b/.github/workflows/pattern-metrics.yaml
@@ -44,7 +44,7 @@ jobs:
         # Extract words from CODEOWNERS that start with @ and convert them into a comma-separated string
         # ie, "-author:spier -author:zkoppert"
         # This will be used to filter out these codeowners from certain stats in later steps
-        CODEOWNERS_FILTER=$(echo $CODEOWNERS_FILE | grep -o "@[a-zA-Z0-9\-]*" | sed 's/@/-author:/g' | tr '\n' ' ')
+        CODEOWNERS_FILTER=$(echo $CODEOWNERS_FILE | grep -o "@[a-zA-Z0-9\-]*" | sed 's/@/-author:/g' | sort | uniq | tr '\n' ' ')
 
         # Print usernames to terminal for easy debugging
         echo "CODEOWNERS_FILTER: $CODEOWNERS_FILTER"
@@ -99,7 +99,7 @@ jobs:
         # Extract words from CODEOWNERS that start with @ and convert them into a comma-separated string
         # ie, "-author:spier -author:zkoppert"
         # This will be used to filter out these codeowners from certain stats in later steps
-        CODEOWNERS_FILTER=$(echo $CODEOWNERS_FILE | grep -o "@[a-zA-Z0-9\-]*" | sed 's/@/-author:/g' | tr '\n' ' ')
+        CODEOWNERS_FILTER=$(echo $CODEOWNERS_FILE | grep -o "@[a-zA-Z0-9\-]*" | sed 's/@/-author:/g' | sort | uniq | tr '\n' ' ')
 
         # Print usernames to terminal for easy debugging
         echo "CODEOWNERS_FILTER: $CODEOWNERS_FILTER"

--- a/.github/workflows/pattern-metrics.yaml
+++ b/.github/workflows/pattern-metrics.yaml
@@ -89,6 +89,10 @@ jobs:
 
     - name: Check out the code so we can get the CODEOWNERS names
       uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          .github/CODEOWNERS
+        sparse-checkout-cone-mode: false
 
     - name: Get usernames from CODEOWNERS file
       shell: bash


### PR DESCRIPTION
- Make the list of CODEOWNERS uniq. Mostly a cosmetic change to make the SEARCH_QUERY shorter
- Use sparse-checkout for the 2nd job as well
