### PR TITLE
Fix URLs of images used by the WelcomeBot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,7 +4,7 @@
 
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: >
-  [![Welcome Banner](https://zenodo.org/api/iiif/v2/0c0188d3-d03c-4830-a6e3-00405f5c22fa:8ff47a85-7250-4d86-8e48-2f346b48b2c1:BannerWelcome.jpg/full/750,/0/default.jpg)](https://zenodo.org/record/3695300)
+  [![Welcome Banner](https://zenodo.org/api/iiif/record:3695300:BannerWelcome.jpg/full/!750,750/0/default.jpg)](https://zenodo.org/record/3695300)](https://zenodo.org/record/3695300)
 
   :tada: Welcome to _The InnerSource Commons_ community, and in particular to our patterns! :tada:
   We're really excited to have your input into the project! :sparkling_heart:
@@ -16,7 +16,7 @@ newIssueWelcomeComment: >
 
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: |
-  [![Thank You Banner](https://zenodo.org/api/iiif/v2/0c0188d3-d03c-4830-a6e3-00405f5c22fa:7fbd97cf-283b-480c-b8e1-11866e26245c:BannerThanks.jpg/full/750,/0/default.jpg)](https://zenodo.org/record/3695300)
+  [![Thank You Banner](https://zenodo.org/api/iiif/record:3695300:BannerThanks.jpg/full/!750,750/0/default.jpg)](https://zenodo.org/record/3695300)
 
   :sparkling_heart: Thanks for opening this pull request! :sparkling_heart: _The InnerSource Commons_ community really appreciates your time and effort to contribute to the project. Please make sure you have read our [Contributing Guidelines](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/main/CONTRIBUTING.md).
 
@@ -32,7 +32,7 @@ newPRWelcomeComment: |
 
 # Comment to be posted to on pull requests merged by a first time user
 firstPRMergeComment: >
-  [![Congratulations Banner](https://zenodo.org/api/iiif/v2/0c0188d3-d03c-4830-a6e3-00405f5c22fa:32fbdb89-ae1b-434e-830c-88ade86724cc:BannerCongratulations.jpg/full/750,/0/default.jpg)](https://zenodo.org/record/3695300)
+  [![Congratulations Banner](https://zenodo.org/api/iiif/record:3695300:BannerCongratulations.jpg/full/!750,750/0/default.jpg)](https://zenodo.org/record/3695300)
 
   Congrats on merging your first pull request! :tada:
   We here at _The InnerSource Commons_ are proud of you! :sparkling_heart:


### PR DESCRIPTION
### Summary

The WelcomeBot that we are using in this repo is using 3 different images to thank new contributors.

I noticed that the images stopped working, as evident in [this example](https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/592#issuecomment-1745249731):

<img width="920" alt="Screenshot 2023-10-25 at 14 00 50" src="https://github.com/InnerSourceCommons/InnerSourcePatterns/assets/163029/da155e1f-6bed-4cd3-9ff0-15e43b80cc86">

I don't know why the old image URLs stopped working.
It might have to do with API changes that were zenodo launched on Oct 13th but that is just a hunch:
https://help.zenodo.org/docs/about/whats-changed/
https://blog.zenodo.org/2022/12/07/2022-12-07-zenodo-on-inveniordm/

zenodo says that their changes should not contain any breaking changes but who knows, maybe this was an unintended side-effect?

_As an aside:_ I tried to find a zenodo Support channel where I can report this issue but could not find an appropriate one sof ar.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* adding new URLs for images used by the WelcomeBot (hosted at zenodo)
