### PR TITLE
Switch to pull_request_target strategy

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
 


### PR DESCRIPTION
fixes #581

This changes from running the gitbook workflow on the upstream repo to actually running it on the fork that a contributor has created with a changeset. The hope is that this will address the failing builds described in #581 . In order to test this change I believe we need to merge this through to the main branch and then open a pull request from a fork which would trigger this github action job.

cc/ @spier 