### PR TITLE
Fix wording in transitioning-contractor-code-to-innersource-model.md

### DIFF
--- a/patterns/1-initial/transitioning-contractor-code-to-innersource-model.md
+++ b/patterns/1-initial/transitioning-contractor-code-to-innersource-model.md
@@ -8,7 +8,7 @@ Contract developers are often not motivated to engage in InnerSource activities,
 
 ## Problem
 
-Contractor developers are often not motivated (through forces described below) to not engage in InnerSource activities. Once delivered, and even if the code is made visible, their projects are often less likely to be part of successful InnerSourced engagements.
+Contractor developers are often not motivated (through forces described below) to engage in InnerSource activities. Once delivered, and even if the code is made visible, their projects are often less likely to be part of successful InnerSource engagements.
 
 ## Context
 


### PR DESCRIPTION
@zkoppert @claredillon I think there was a double negation introduced here that changed the meaning in the wrong way. At least the description in the "Problem" section that I am changing in this PR did not fit to what the "Patlet" says.

Also while we are talking about this, question to @gyehuda and @zkoppert:
Did you make any new experiences in this space that you can share?

We got another question about this area in Slack, so the topic of "agency code & InnerSource" could be relevant to explore a bit deeper.