### PR TITLE
base-documentation.md - add Communication template to References section 

### DIFF
--- a/patterns/2-structured/base-documentation.md
+++ b/patterns/2-structured/base-documentation.md
@@ -137,10 +137,11 @@ started right away: [README-template.md](templates/README-template.md),
 ## Authors
 
 * Isabel Drost-Fromm
-
+* Katie Schueths
+  
 ## Acknowledgments
 
-* Katie Schueths - for adding the `COMMUNICATION.md` concept
+
 
 ## Alias
 
@@ -153,8 +154,9 @@ Provide standard base documentation through a README
 
 ## References
 
-* [README-template.md](templates/README-template.md) and
+* [README-template.md](templates/README-template.md)
 * [CONTRIBUTING-template.md](templates/CONTRIBUTING-template.md)
+* [COMMUNICATION-template.md](templates/COMMUNICATION-template.md)
 
 ## Credits
 

--- a/patterns/2-structured/base-documentation.md
+++ b/patterns/2-structured/base-documentation.md
@@ -138,10 +138,6 @@ started right away: [README-template.md](templates/README-template.md),
 
 * Isabel Drost-Fromm
 * Katie Schueths
-  
-## Acknowledgments
-
-
 
 ## Alias
 

--- a/patterns/2-structured/base-documentation.md
+++ b/patterns/2-structured/base-documentation.md
@@ -137,7 +137,7 @@ started right away: [README-template.md](templates/README-template.md),
 ## Authors
 
 * Isabel Drost-Fromm
-* Katie Schueths
+* Katie Schueths - for adding the `COMMUNICATION.md` concept
 
 ## Alias
 

--- a/patterns/2-structured/base-documentation.md
+++ b/patterns/2-structured/base-documentation.md
@@ -137,7 +137,7 @@ started right away: [README-template.md](templates/README-template.md),
 ## Authors
 
 * Isabel Drost-Fromm
-* Katie Schueths - for adding the `COMMUNICATION.md` concept
+* Katie Schueths - added the `COMMUNICATION.md` concept
 
 ## Alias
 


### PR DESCRIPTION
Added link to Communication template and corrected author to reflect COMMUNICATION.md template author and pattern modification..