### PR TITLE
Add SAP as known instance for the 30 Day Warranty and Praise Participants patterns

### DIFF
--- a/patterns/2-structured/30-day-warranty.md
+++ b/patterns/2-structured/30-day-warranty.md
@@ -49,6 +49,8 @@ In addition it helps to provide clear [contribution guidelines](./base-documenta
 - This was tried and proven successful at PayPal.
 - GitHub internally uses this pattern with a modified warranty timeline of 6 weeks.
 - Microsoft recommends this pattern as a principle - teams set their own specific time target matching their needs and confidence.
+- SAP
+  - See: [InnerSource: First Contribution Explored](https://community.sap.com/t5/open-source-blogs/innersource-first-contribution-explored/ba-p/13644916)
 
 ## Authors
 

--- a/patterns/2-structured/30-day-warranty.md
+++ b/patterns/2-structured/30-day-warranty.md
@@ -49,8 +49,7 @@ In addition it helps to provide clear [contribution guidelines](./base-documenta
 - This was tried and proven successful at PayPal.
 - GitHub internally uses this pattern with a modified warranty timeline of 6 weeks.
 - Microsoft recommends this pattern as a principle - teams set their own specific time target matching their needs and confidence.
-- SAP
-  - See: [InnerSource: First Contribution Explored](https://community.sap.com/t5/open-source-blogs/innersource-first-contribution-explored/ba-p/13644916)
+- SAP - see: [InnerSource: First Contribution Explored](https://community.sap.com/t5/open-source-blogs/innersource-first-contribution-explored/ba-p/13644916)
 
 ## Authors
 

--- a/patterns/2-structured/praise-participants.md
+++ b/patterns/2-structured/praise-participants.md
@@ -68,8 +68,7 @@ Overdoing it may feel insincere and mechanical and defeat your purpose in reachi
 ## Known Instances
 
 * Nike (multiple projects)
-* SAP
-  * See: [InnerSource: First Contribution Explored](https://community.sap.com/t5/open-source-blogs/innersource-first-contribution-explored/ba-p/13644916)
+* SAP - see: [InnerSource: First Contribution Explored](https://community.sap.com/t5/open-source-blogs/innersource-first-contribution-explored/ba-p/13644916)
 
 ## Status
 

--- a/patterns/2-structured/praise-participants.md
+++ b/patterns/2-structured/praise-participants.md
@@ -68,6 +68,8 @@ Overdoing it may feel insincere and mechanical and defeat your purpose in reachi
 ## Known Instances
 
 * Nike (multiple projects)
+* SAP
+  * See: [InnerSource: First Contribution Explored](https://community.sap.com/t5/open-source-blogs/innersource-first-contribution-explored/ba-p/13644916)
 
 ## Status
 


### PR DESCRIPTION
Recently during one of our internal SAP InnerSource focused workstream meetings I inquired about guidance for making a pull request to add SAP as a known instance for existing patterns.  The conversation with @dellagustin surfaced an idea that a known instance for a pattern should have a basis for such a claim.

As such, I have captured the spirit of the value we are finding in one of my home group/departments as described in the following blog article:

* https://community.sap.com/t5/open-source-blogs/innersource-first-contribution-explored/ba-p/13644916

I linked the article to the known instance in the proposed modified files.

Please let me know how this sits and or if there are changes desired.

Warmly.
Michael Basil 🙏 🌿