### PR TITLE
Fix glossary in book

### DIFF
--- a/book/en/toc.md
+++ b/book/en/toc.md
@@ -47,6 +47,7 @@ Instead edit toc_template.md
 ## Appendix
 
 * [Pattern Template](../../meta/pattern-template.md)
+* [Glossary](../../meta/glossary.md)
 * Extras
   * [README Template](../../patterns/2-structured/templates/README-template.md)
   * [CONTRIBUTING Template](../../patterns/2-structured/templates/CONTRIBUTING-template.md)

--- a/book/en/toc_template.md
+++ b/book/en/toc_template.md
@@ -35,3 +35,4 @@ Instead edit toc_template.md
 
 * [This book on GitHub](https://github.com/InnerSourceCommons/InnerSourcePatterns)
 * [InnerSource Commons](http://innersourcecommons.org)
+

--- a/book/en/toc_template.md
+++ b/book/en/toc_template.md
@@ -35,4 +35,3 @@ Instead edit toc_template.md
 
 * [This book on GitHub](https://github.com/InnerSourceCommons/InnerSourcePatterns)
 * [InnerSource Commons](http://innersourcecommons.org)
-


### PR DESCRIPTION
The re-generation of the table of contents for the book only works when triggered by a repo Admin.
This is a known issue that we still haven't fixed yet.

Pushing this dummy PR with no changes, so that we can get the glossary published.

