### PR TITLE
Actions are changed from default branch to version-specified.

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Vale Linting
-      uses: errata-ai/vale-action@reviewdog
+      uses: errata-ai/vale-action@v2
       with:
         files: '["patterns/2-structured/", "patterns/3-validated/"]'
         vale_flags: "--glob=*.md"


### PR DESCRIPTION
# Summary
The default branch named `reviewdog` was specified, so it was changed to the version specification.
It is expected to be resistant to errata-ai/vale-action changes.