### PR TITLE
Update lychee config

### DIFF
--- a/.github/workflows/link-checker-prs.yml
+++ b/.github/workflows/link-checker-prs.yml
@@ -39,7 +39,7 @@ jobs:
         name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --exclude-mail --cache --max-cache-age 1d $MARKDOWN_FILES
+          args: --verbose --no-progress --cache --max-cache-age 1d $MARKDOWN_FILES
           fail: true
           jobSummary: true
         env:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --exclude-mail --cache --max-cache-age 1d README.md patterns/ book/ translation/
+          args: --verbose --no-progress --cache --max-cache-age 1d README.md patterns/ book/ translation/
           fail: true
           jobSummary: true
         env:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -10,6 +10,6 @@ https://ulir.ul.ie/bitstream/handle/10344/4443/Stol_2014_inner.pdf
 .*@andrew.clegg.*
 https://m.dotdev.co/how-to-write-a-readme-that-rocks-bc29f279611a
 https://www.chathamhouse.org/about-us/chatham-house-rule
-
+https://www.linkedin.com/in
 # from source-code-inventory.md / no longer reachable but we want to keep the link in the pattern in case we find it again.
 https://github.com/trieshard/source-strategy-assessment/blob/master/framework.md


### PR DESCRIPTION
Fix failing GHA for link checks.

Also a minor fix: Removing this warning
```[WARN ] WARNING: `--exclude-mail` is deprecated and will soon be removed; E-Mail is no longer checked by default. Use `--include-mail` to enable E-Mail checking.```