### PR TITLE
Update maturity-model.md - minor formatting change

### DIFF
--- a/patterns/2-structured/maturity-model.md
+++ b/patterns/2-structured/maturity-model.md
@@ -33,8 +33,7 @@ InnerSource project differs depending on each team.
 Teams sharing InnerSource learnings run into misunderstandings as they are not
 aware of their respective level of InnerSource adoption.
 
-Teams believe that "it's all about migrating to a shared software development
-[forge](https://en.wikipedia.org/wiki/Forge_%28software%29)" (GitLab, GitHub, or Bitbucket being well known examples of such forges).
+Teams believe that "it's all about migrating to a shared software development [forge](https://en.wikipedia.org/wiki/Forge_%28software%29)" (GitLab, GitHub, or Bitbucket being well known examples of such forges).
 
 Teams are not aware of best practices that would help them solve issues that
 they run into in their daily doing.


### PR DESCRIPTION
Moved a split sentence into a single line, trying to solve a rendering issue on GitBook. "development" and "forge" are rendered without a space between the two words.

<img width="845" alt="screenshot of the Forces section of the Maturity Model pattern, point out that the development and forge words are rendered as one" src="https://github.com/user-attachments/assets/4521c35f-3f2a-4e9b-9cf9-1a07af4b8763" />
