### PR TITLE
Fix link to DBSystel InnerSource License

### DIFF
--- a/patterns/2-structured/innersource-license.md
+++ b/patterns/2-structured/innersource-license.md
@@ -108,5 +108,5 @@ For more details see the InnerSource Commons Community call from 09/2023 [Improv
 - **organization** - An umbrella for multiple legal entities. (synonyms: group, enterprise) (e.g. Lufthansa)
 - **legal entity** - An entity that has its own legal rights and obligations (synonyms: company, subsidiary) (e.g. Lufthansa Systems GmbH, Lufthansa Industry Solutions TS GmbH, ...)
 
-[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/blob/master/DB-Inner-Source-License.md
+[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/tree/master/inner-source-license
 [eupl]: https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12

--- a/translation/es/patterns/innersource-license.md
+++ b/translation/es/patterns/innersource-license.md
@@ -107,7 +107,7 @@ Para más detalles, vea la llamada de la Comunidad InnerSource Commons de 09/202
 - **organización** - Un paraguas para múltiples entidades legales. (sinónimos: grupo, empresa) (por ejemplo, Lufthansa)
 - **entidad legal** - Una entidad que tiene sus propios derechos y obligaciones legales (sinónimos: empresa, subsidiaria) (por ejemplo, Lufthansa Systems GmbH, Lufthansa Industry Solutions TS GmbH, ...)
 
-[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/blob/master/DB-Inner-Source-License.md
+[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/tree/master/inner-source-license
 [eupl]: https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
 
 ## Histórico de Traducciones

--- a/translation/gl/patterns/innersource-license.md
+++ b/translation/gl/patterns/innersource-license.md
@@ -51,7 +51,7 @@ A licenza simplifica as conversas dentro da organización sobre o feito de compa
 
 ## Exemplos coñecidos
 
-DB Systel creou a súa propia licenza InnerSource, pódese consultar en [DB Inner Source License](https://github.com/dbsystel/open-source-policies/blob/master/DB-Inner-Source-License.md). Usaron a [EUPL](https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12), xa que ofrecía un software libre como punto de partida, e despois elaboraron as limitacións e as regras adicionais necesarias no seu contexto organizativo específico.
+DB Systel creou a súa propia licenza InnerSource, pódese consultar en [DB Inner Source License][db-inner-source-license]. Usaron a [EUPL][eupl], xa que ofrecía un software libre como punto de partida, e despois elaboraron as limitacións e as regras adicionais necesarias no seu contexto organizativo específico.
 
 As primeiras entidades xurídicas (empresas) dentro da DB AG están a usar a súa licenza InnerSource.
 
@@ -80,12 +80,15 @@ Paga a pena mencionar que, ata agora, o software compartido baixo esta licenza I
 ## Referencias
 
 - Presentación FOSSBack 2020: [Cornelius Schumacher - Blending Open Source and Corporate Values](https://youtu.be/hikC6U8X_Ec) [Cornelius Schumacher: Mesturando código aberto e valores corporativos]; vexa a partir do minuto 27:30 para máis información sobre a licenza InnerSource.
-- [DB Inner Source License](https://github.com/dbsystel/open-source-policies/blob/master/DB-Inner-Source-License.md).
+- [DB Inner Source License][db-inner-source-license].
 
 ## Glosario
 
 - **Organización**: un paraugas para varias entidades xurídicas. (Sinónimos: grupo, empresa. Por exemplo, Lufthansa.).
 - **Entidade xurídica**: unha entidade que ten os seus propios dereitos e obrigas legais. (Sinónimos: empresa, filial. Por exemplo, Lufthansa Systems GmbH, Lufthansa Industry Solutions TS GmbH etc).
+
+[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/tree/master/inner-source-license
+[eupl]: https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
 
 ## Tradución
 

--- a/translation/ja/patterns/innersource-license.md
+++ b/translation/ja/patterns/innersource-license.md
@@ -89,7 +89,7 @@ DB 社の中で最初の法人(企業) は、このインナーソース ライ�
 - **組織** - 複数の企業の母体(同義語: グループ、ホールディング、エンタープライズ) (例: Microsoft Corporation)
 - **法的エンティティ** - 独自の法的権利と義務を有するエンティティ (同義語: グループ子会社、子会社、関連会社) (例: Microsoft Japan, GitHub, LinkedIn)
 
-[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/blob/master/DB-Inner-Source-License.md
+[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/tree/master/inner-source-license
 [eupl]: https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
 
 ## 翻訳の履歴

--- a/translation/pt-br/patterns/innersource-license.md
+++ b/translation/pt-br/patterns/innersource-license.md
@@ -87,7 +87,7 @@ Vale mencionar que até agora, o software compartilhado sob essa licença InnerS
 - organização - um guarda-chuva para várias entidades legais. (sinônimos: grupo, empresa) (e.g., Lufthansa)
 -entidade jurídica - Uma entidade que possui seus próprios direitos e obrigações legais (sinônimos: empresa, subsidiária) (por exemplo, Lufthansa Systems GmbH, Lufthansa Industry Solutions TS GmbH, ...)
 
-[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/blob/master/DB-Inner-Source-License.md
+[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/tree/master/inner-source-license
 [eupl]: https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
 
 ## Histórico de Tradução

--- a/translation/zh/patterns/innersource-license.md
+++ b/translation/zh/patterns/innersource-license.md
@@ -87,7 +87,7 @@ DB AG内部的第一批法律实体（公司）正在使用他们的内源许可
 - **组织** - 多个法律实体的综合体。(同义词：集团、企业）（如汉莎航空）。
 - **法律实体** - 拥有自身的法律权利和义务的实体（同义词：公司，子公司）（例如汉莎系统有限公司，汉莎工业解决方案TS有限公司，...）
 
-[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/blob/master/DB-Inner-Source-License.md
+[db-inner-source-license]: https://github.com/dbsystel/open-source-policies/tree/master/inner-source-license
 [eupl]: https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
 
 ## 翻译校对


### PR DESCRIPTION
Noticed a broken link in [this check](https://github.com/InnerSourceCommons/InnerSourcePatterns/actions/runs/17488150853).