### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,5 +1,8 @@
 name: Gitbook Generation
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/5](https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/5)

To fix the problem, we should add a `permissions` block to the workflow file `.github/workflows/book.yml`. The block should be added at the workflow root (top-level, after `name:` and before `jobs:`), so the permissions apply to all jobs in the workflow. The least privilege required is `contents: write` so the job can push changes to the repo (required by the auto-commit step). Other permissions (such as `pull-requests: write`) are not required for this workflow, as it does not modify pull requests or other resources. The block should be added after the workflow `name:` and before the `jobs:` key (best practice is before any uses of the jobs).

No imports or additional methods/definitions are needed; it's a change to the workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
