### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/i18n-consistency-checker.yaml
+++ b/.github/workflows/i18n-consistency-checker.yaml
@@ -4,6 +4,9 @@
 # - add the flag and language name that you want to use at the beginning of the #check-consistency step
 # -------------------------
 name: i18n Consistency Check
+permissions:
+  contents: read
+  issues: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/6](https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow file at the job or root level, specifying the least privileges required for the workflow to operate. In this case, the workflow reads repository contents and uses `gh` to create and comment on issues. Therefore, you should set `contents: read` and `issues: write`. Place the `permissions` block at the root level so it applies to all jobs, typically immediately under the `name` field, before the `on:` field.

Specific steps:
- In the file `.github/workflows/i18n-consistency-checker.yaml`  
- Insert the following block after `name: i18n Consistency Check` (line 6):

  ```yaml
  permissions:
    contents: read
    issues: write
  ```

No other code, imports, or settings need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
