### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-patterns.yml
+++ b/.github/workflows/lint-patterns.yml
@@ -3,6 +3,9 @@
 # markdownlint -r config/lint/pattern-template.js -c config/lint/pattern-template.yml patterns/2-structured/*.md patterns/3-validated/*.md
 name: Pattern Syntax Validation
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/9](https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/9)

To fix this problem, add an explicit `permissions` block as recommended to the workflow (either at the root level for all jobs, or at the job level for just this job). Since the workflow only needs to read repository contents (it does not create issues, pull requests, releases, or modify anything), grant only `contents: read` permission. The best way is to add this block just before `jobs:` at the top level of the YAML file, so every job inherits it (and it is easy to edit later if needed). No new imports or complex configuration is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
