### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,4 +1,6 @@
 name: Markdownlint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/10](https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/10)

To fix this problem, add an explicit `permissions` block at the workflow or job level. Since this workflow doesn't need to write to the repository or manage issues/pull requests, the minimum required is:
```yaml
permissions:
  contents: read
```
This should be placed at the top workflow level (just under `name:` or above `on:`), so it applies to all jobs.  
No further code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
