### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,4 +1,6 @@
 name: Spelling & Styles
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/11](https://github.com/InnerSourceCommons/InnerSourcePatterns/security/code-scanning/11)

To fix the problem, you should explicitly declare a `permissions` block at the workflow (top) or job (vale job) level. This block should enumerate only the minimum permissions needed for the workflow's actions. In this specific case, the job only checks out code and runs Vale analysis. No write access or additional scopes are needed; `contents: read` will suffice.

The most straightforward method is to add `permissions: contents: read` near the top (right under the `name`) so it applies to all jobs in the workflow. Alternatively, you can add it under the `vale` job for just that job—but given there is only one job, placing it under the workflow header is cleaner.

**What to change:**  
Modify `.github/workflows/vale.yml` to insert:

```yaml
permissions:
  contents: read
```

just after the `name: Spelling & Styles` line and before the `on:` block.

**No additional imports, methods, or definitions are required since this is just a configuration file change.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
