### PR TITLE
Upgrade to commonmarker 0.23.10 to fix the dependabot alerts

### DIFF
--- a/book/scripts/Gemfile
+++ b/book/scripts/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'commonmarker', "0.18.2"
+gem 'commonmarker', "0.23.10"


### PR DESCRIPTION
Upgrade to commonmarker 0.23.10 to fix the various dependabot alerts