### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/contributor-report.yaml
+++ b/.github/workflows/contributor-report.yaml
@@ -28,7 +28,7 @@ jobs:
         echo "END_DATE=$end_date" >> "$GITHUB_ENV"
 
     - name: Run contributor action
-      uses: github/contributors@v1
+      uses: github-community-projects/contributors@v1
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         START_DATE: ${{ env.START_DATE }}

--- a/.github/workflows/pattern-metrics.yaml
+++ b/.github/workflows/pattern-metrics.yaml
@@ -53,7 +53,7 @@ jobs:
         echo "CODEOWNERS_FILTER=$CODEOWNERS_FILTER" >> "$GITHUB_ENV"
 
     - name: Run issue-metrics tool for issues
-      uses: github/issue-metrics@v3
+      uses: github-community-projects/issue-metrics@v3
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:InnerSourceCommons/InnerSourcePatterns is:issue created:${{ env.last_month }} -reason:"not planned" ${{ env.CODEOWNERS_FILTER }}'
@@ -66,7 +66,7 @@ jobs:
         mv ./issue_metrics.md ready_to_merge_issues_report.md
 
     - name: Run issue-metrics tool for PRs
-      uses: github/issue-metrics@v3
+      uses: github-community-projects/issue-metrics@v3
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:InnerSourceCommons/InnerSourcePatterns is:pr created:${{ env.last_month }} -reason:"not planned" ${{ env.CODEOWNERS_FILTER }}'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/contributors` | `github-community-projects/contributors` |
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
