### PR TITLE
Pin Vale to 3.14.2 to fix dicpath resolution regression

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -27,3 +27,4 @@ jobs:
         vale_flags: "--glob=*.md"
         filter_mode: added
         debug: true
+        version: 3.14.2


### PR DESCRIPTION
## Summary

The `Spelling & Styles` workflow has failed on every PR (and the monthly `main` schedule run) since 2026-06-15, with `vale` erroring `unable to resolve dicpath` on `.github/vale/ISC/Spelling.yml` — unrelated to any PR's content.

## Root cause

`vale-action@v2` defaults to `version: latest`. Vale [3.15.0](https://github.com/errata-ai/vale/releases/tag/v3.15.0) (released 2026-06-12) changed `vale sync` to create and use the configured `StylesPath` (`.github/vale`) instead of falling back to a global styles directory (errata-ai/vale#1106). That changed where the `ISC` package's nested `styles/ISC/Spelling.yml` and `styles/dictionaries/` land once synced, breaking `Spelling.yml`'s relative `dicpath: dictionaries`.

`3.14.2` was the last Vale release before that sync change — pinning to it restores the working layout. The [isc-styles](https://github.com/InnerSourceCommons/isc-styles) package itself hasn't changed since 2025-08-28, so this is a Vale-version compatibility issue, not a content or package issue.

## Fix

Pin `vale-action`'s `version` input to `3.14.2` instead of floating on `latest`.

## Longer-term

`isc-styles`' `Spelling.yml`/`dicpath` should eventually be restructured to work under the new (correct) sync behavior so we can move off the pin — filing that separately against `isc-styles`.

## Test plan

- [x] This PR's own `Spelling & Styles` check should now pass (self-verifying, since `pull_request` runs the workflow from this branch).
