### PR TITLE
Fix link checker false positives on root-relative asset links

### DIFF
--- a/.github/workflows/link-checker-prs.yml
+++ b/.github/workflows/link-checker-prs.yml
@@ -39,7 +39,7 @@ jobs:
         name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --cache --max-cache-age 1d $MARKDOWN_FILES
+          args: --verbose --no-progress --cache --max-cache-age 1d --root-dir . $MARKDOWN_FILES
           fail: true
           failIfEmpty: false
           jobSummary: true


### PR DESCRIPTION
## Problem

The link checker workflow only lints files changed in a PR, specifically to avoid failing PRs on pre-existing issues unrelated to their content — the workflow's own top comment says so.
But it still checks every link in a changed file, not just the diff, so any pre-existing root-relative link (e.g. `/assets/img/foo.png`) in a touched file trips it, since lychee isn't told the repo root and can't resolve a path starting with `/`.

This surfaced in #926, which failed the check on a pre-existing image link in `patterns/1-initial/internal-developer-platform.md` that the PR never touched — it only added a "Known Instances" bullet elsewhere in the file.

## Fix

Pass `--root-dir .` to lychee so root-relative links resolve against the repo root instead of failing outright.
